### PR TITLE
Attempt to to set our own soft limits

### DIFF
--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -1827,7 +1827,7 @@ static struct MHD_Daemon *datum_api_try_start(unsigned int flags, const int sock
 	                          NULL, NULL,  // accept policy filter
 	                          &datum_api_answer, NULL,  // default URI handler
 	                          MHD_OPTION_LISTEN_SOCKET, sock,
-	                          MHD_OPTION_CONNECTION_LIMIT, 128,
+	                          MHD_OPTION_CONNECTION_LIMIT, DATUM_API_CONNECTION_LIMIT,
 	                          MHD_OPTION_NOTIFY_COMPLETED, datum_api_request_completed, NULL,
 	                          MHD_OPTION_LISTENING_ADDRESS_REUSE, (unsigned int)1,
 	                          MHD_OPTION_END);

--- a/src/datum_api.h
+++ b/src/datum_api.h
@@ -38,6 +38,8 @@
 
 #include "datum_stratum.h"
 
+#define DATUM_API_CONNECTION_LIMIT 128
+
 typedef struct {
 	int STRATUM_ACTIVE_THREADS;
 	int STRATUM_TOTAL_CONNECTIONS;


### PR DESCRIPTION
1. attempt to set out own soft limits
2. align wording: "hard open file limit" and "soft open file limit"

We basically check if max_clients is higher than the soft limit and if so, set the soft limit to the max_clients or the hard limit, if max_clients is higher.

It looks like this in action (when I doubled the defaults):
```
2024-10-22 21:51:39.315 [              datum_stratum_v1_socket_server]  INFO: Stratum V1 Server Init complete.
2024-10-22 21:51:39.315 [              datum_stratum_v1_socket_server]  WARN: *** NOTE *** Max Stratum clients (2048) exceeds soft open file limit (Soft: 1024 / Hard: 1048576)
2024-10-22 21:51:39.315 [              datum_stratum_v1_socket_server]  WARN: *** NOTE *** Attempting to increase the soft limit...
2024-10-22 21:51:39.315 [              datum_stratum_v1_socket_server]  INFO: Successfully increased the soft open file limit to 2048
```

Now that I suggest this PR. Is setting the limits to max_clients sufficient? Surely not, because there are other files open.
This of course doesn't invalidate this PR, because it does what it is supposed to, but I suppose we should have more room.