### PR TITLE
Fix bugs in datum_queue_free

### DIFF
--- a/src/datum_queue.c
+++ b/src/datum_queue.c
@@ -65,14 +65,17 @@ int datum_queue_free(DATUM_QUEUE *q) {
 	if (q->buffer[0]) {
 		free(q->buffer[0]);
 	}
+	if (q->buffer[1]) {
+		free(q->buffer[1]);
+	}
 	
 	q->initialized = false;
 	q->buffer[0] = 0;
-	q->buffer[0] = 0;
+	q->buffer[1] = 0;
 	
-	pthread_rwlock_unlock(&q->active_buffer_rwlock);
-	pthread_rwlock_unlock(&q->buffer_rwlock[0]);
 	pthread_rwlock_unlock(&q->buffer_rwlock[1]);
+	pthread_rwlock_unlock(&q->buffer_rwlock[0]);
+	pthread_rwlock_unlock(&q->active_buffer_rwlock);
 	
 	pthread_rwlock_destroy(&q->active_buffer_rwlock);
 	pthread_rwlock_destroy(&q->buffer_rwlock[0]);

--- a/src/datum_queue.c
+++ b/src/datum_queue.c
@@ -131,7 +131,8 @@ int datum_queue_add_item(DATUM_QUEUE *q, void *item) {
 	// Add the msg to the logger queue
 	// this is probably overkill...
 	for (i=0;i<10000000;i++) {
-		if (i < 99999990) { // ensure we don't get the lock on the last try and forget to unlock and crash
+		if (i < 9999999) { // ensure we don't get the lock on the last try and forget to unlock and crash
+			
 			// get the active buffer ID
 			pthread_rwlock_rdlock(&q->active_buffer_rwlock);
 			buffer_id = q->active_buffer;

--- a/src/datum_queue.c
+++ b/src/datum_queue.c
@@ -65,13 +65,9 @@ int datum_queue_free(DATUM_QUEUE *q) {
 	if (q->buffer[0]) {
 		free(q->buffer[0]);
 	}
-	if (q->buffer[1]) {
-		free(q->buffer[1]);
-	}
 	
 	q->initialized = false;
 	q->buffer[0] = 0;
-	q->buffer[1] = 0;
 	
 	pthread_rwlock_unlock(&q->buffer_rwlock[1]);
 	pthread_rwlock_unlock(&q->buffer_rwlock[0]);


### PR DESCRIPTION
1. q->buffer[1] doesn't seem to be free()'d

2. q->buffer[0] is duplicated, you probably meant to zero out buffer[1]

3. shouldn't the unlocking order be reverse of locking order to prevent deadlocks?