### PR TITLE
Improve error messages of fopen() calls

### DIFF
--- a/src/datum_logger.c
+++ b/src/datum_logger.c
@@ -49,6 +49,7 @@
 #include <inttypes.h>
 #include <stdbool.h>
 #include <pthread.h>
+#include <errno.h>
 
 #include "datum_logger.h"
 #include "datum_utils.h"
@@ -275,7 +276,7 @@ void * datum_logger_thread(void *ptr) {
 	if ((log_to_file) && (log_file[0] != 0)) {
 		log_handle = fopen(log_file,"a");
 		if (!log_handle) {
-			DLOG(DLOG_LEVEL_FATAL, "Could not open log file!");
+			DLOG(DLOG_LEVEL_FATAL, "Could not open log file (%s): %s!", log_file, strerror(errno));
 			panic_from_thread(__LINE__);
 		}
 	}
@@ -392,13 +393,14 @@ void * datum_logger_thread(void *ptr) {
 				log_line[1199] = 0;
 				
 				fclose(log_handle);
+
 				if (rename(log_file, log_line) != 0) {
-					DLOG(DLOG_LEVEL_ERROR, "Could not rename log file for rotation!");
+					DLOG(DLOG_LEVEL_ERROR, "Could not rename log file (%s) for rotation: %s!", log_file, strerror(errno));
 				}
 				
 				log_handle = fopen(log_file,"a");
 				if (!log_handle) {
-					DLOG(DLOG_LEVEL_FATAL, "Could not open log file after rotation!");
+					DLOG(DLOG_LEVEL_FATAL, "Could not open log file (%s) after rotation: %s!", log_file, strerror(errno));
 					panic_from_thread(__LINE__);
 				}
 				

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -2144,10 +2144,10 @@ int assembleBlockAndSubmit(uint8_t *block_header, uint8_t *coinbase_txn, size_t 
 		userpass[511] = 0;
 		f = fopen(userpass, "w");
 		if (!f) {
-			DLOG_ERROR("Could not open %s for writing submitblock record to disk!", userpass);
+			DLOG_ERROR("Could not open %s for writing submitblock record to disk: %s!", userpass, strerror(errno));
 		} else {
 			if (!fwrite(submitblock_req, ptr-submitblock_req, 1, f)) {
-				DLOG_ERROR("Could not write to %s when writing submitblock record to disk!", userpass);
+				DLOG_ERROR("Could not write to %s when writing submitblock record to disk: %s!", userpass, strerror(errno));
 			}
 			fclose(f);
 		}


### PR DESCRIPTION
It helped me find an issue in my config. The error message from fopen, and the filename I was trying to open