### PR TITLE
Fix superfluous newline in log when getaddrinfo fails

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -1497,7 +1497,7 @@ void *datum_protocol_client(void *args) {
 	port_str[6] = 0;
 	
 	if ((ret = getaddrinfo(datum_config.datum_pool_host, port_str, &hints, &res)) != 0) {
-		DLOG_ERROR("getaddrinfo: %s\n", gai_strerror(ret));
+		DLOG_ERROR("getaddrinfo: %s", gai_strerror(ret));
 		datum_protocol_client_active = 0;
 		return NULL;
 	}


### PR DESCRIPTION
What happens is that you can get this in the log.
```
2024-12-10 17:30:02.356 [                       datum_protocol_client] ERROR: getaddrinfo: Name or service not known

2024-12-10 17:30:28.964 [               datum_gateway_template_thread] DEBUG: DEBUG: calling datum_gbt_parser (new=0)
```
