### PR TITLE
Bring status output to current web standards

### DIFF
--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -644,7 +644,7 @@ int datum_api_client_dashboard(struct MHD_Connection *connection) {
 		}
 	}
 	
-	sz += snprintf(&output[sz], max_sz-1-sz, "</TABLE><BR><CENTER>Total active hashrate estimate: %.2f Th/s</CENTER>", thr);
+	sz += snprintf(&output[sz], max_sz-1-sz, "</TABLE><p class=\"table-footer\">Total active hashrate estimate: %.2f Th/s</p>", thr);
 	sz += snprintf(&output[sz], max_sz-1-sz, "<script>function sendPostRequest(url, data){fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});}</script>");
 	sz += snprintf(&output[sz], max_sz-1-sz, "%s", www_foot_html);
 	

--- a/www/assets/style.css
+++ b/www/assets/style.css
@@ -138,3 +138,8 @@ td:not(.label) {
 .fixed-width {
 	font-family: "Courier New", Courier, monospace;
 }
+
+.note {
+	text-align: center;
+	font-size: small;
+}

--- a/www/assets/style.css
+++ b/www/assets/style.css
@@ -119,6 +119,11 @@ td:not(.label) {
 	background-color: black;
 }
 
+.table-footer {
+	text-align: center;
+	margin-top: 30px;
+}
+
 @media (min-width: 1100px) {
 	.table-wrapper {
 		flex-wrap: nowrap;

--- a/www/clients_top.html
+++ b/www/clients_top.html
@@ -5,6 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 	<div class="container">

--- a/www/coinbaser_top.html
+++ b/www/coinbaser_top.html
@@ -5,6 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>
 		.table-wrapper {
 			justify-content: center;

--- a/www/coinbaser_top.html
+++ b/www/coinbaser_top.html
@@ -5,7 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
-	<style type="text/css">
+	<style>
 		.table-wrapper {
 			justify-content: center;
 		}

--- a/www/foot.html
+++ b/www/foot.html
@@ -1,7 +1,6 @@
 			</div>
 		</div>
 	</div>
-	<BR>
-	<CENTER><SMALL>Note: This page does not automatically refresh</SMALL></CENTER>
+	<p class="note">Note: This page does not automatically refresh</p>
 </body>
 </html>

--- a/www/home.html
+++ b/www/home.html
@@ -5,6 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>
 		.table-wrapper {
 			justify-content: center;

--- a/www/home.html
+++ b/www/home.html
@@ -170,7 +170,6 @@
 		</div>
 		</div>
 	</div>
-	<BR>
-	<CENTER><SMALL>Note: This page does not automatically refresh</SMALL></CENTER>
+	<p class="note">Note: This page does not automatically refresh</p>
 </body>
 </html>

--- a/www/home.html
+++ b/www/home.html
@@ -5,7 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
-	<style type="text/css">
+	<style>
 		.table-wrapper {
 			justify-content: center;
 		}

--- a/www/threads_top.html
+++ b/www/threads_top.html
@@ -5,6 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style>
 		.table-wrapper {
 			justify-content: center;

--- a/www/threads_top.html
+++ b/www/threads_top.html
@@ -5,7 +5,7 @@
 	<title>DATUM Gateway Status</title>
 	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
 	<link rel="stylesheet" type="text/css" href="./assets/style.css">
-	<style type="text/css">
+	<style>
 		.table-wrapper {
 			justify-content: center;
 		}


### PR DESCRIPTION
Minor cleanup of HTML/CSS for status pages:
- remove deprecated attribute on style element
- replace obsolete CENTER attribute using CSS classes

All HTML+CSS now validates cleanly. May be minor changes to spacing.