### PR TITLE
Added sample systemd service file

### DIFF
--- a/contrib/init/datum_gateway.service
+++ b/contrib/init/datum_gateway.service
@@ -1,0 +1,89 @@
+[Unit]
+Description=DATUM Gateway
+Documentation=https://github.com/OCEAN-xyz/datum_gateway
+
+#
+# Expected file locations when using hardening options:
+# binary: /usr/bin/datum/
+# configuration: /etc/datum/
+# logs: /var/lib/datum_gateway/
+#
+
+# https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/
+Wants=network-online.target
+After=network-online.target
+# alternatively, wait until bitcoind is up
+#After=bitcoind.service
+
+[Service]
+
+ExecStart=/usr/bin/datum/datum_gateway --config=/etc/datum/datum_gateway_config.json
+
+# Make sure the config directory is readable by the service user
+PermissionsStartOnly=true
+ExecStartPre=/bin/chgrp datum /etc/datum
+
+#
+# Process Management
+#
+
+Type=simple
+NotifyAccess=all
+PIDFile=/run/datum/datum_gateway.pid
+
+Restart=on-failure
+TimeoutStartSec=infinity
+TimeoutStopSec=600
+
+# limit number of open file descriptors
+LimitNOFILE=65535
+
+#
+# Directory Creation & Permissions
+#
+
+User=datum
+Group=datum
+
+# /run/datum_gateway
+RuntimeDirectory=datum_gateway
+RuntimeDirectoryMode=0710
+
+# /etc/datum
+ConfigurationDirectory=datum
+ConfigurationDirectoryMode=0710
+
+# /var/lib/datum_gateway
+StateDirectory=datum_gateway
+StateDirectoryMode=0710
+
+#
+# Hardening
+#
+
+# Provide a private /tmp and /var/tmp
+PrivateTmp=true
+
+# Mount /usr, /boot/ and /etc read-only for the process
+ProtectSystem=full
+
+# Deny access to /home, /root and /run/user
+ProtectHome=true
+
+# Disallow the process and all of its children to gain
+# new privileges through execve()
+NoNewPrivileges=true
+
+# Use a new /dev namespace only populated with API pseudo devices
+# such as /dev/null, /dev/zero and /dev/random
+PrivateDevices=true
+
+# Deny the creation of writable and executable memory mappings
+MemoryDenyWriteExecute=true
+
+# Restrict ABIs to help ensure MemoryDenyWriteExecute is enforced
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Added sample systemd service file patterned after bitcoind example file. Includes hardening options and comments with guide to expected file locations. Also creates `contrib/init` path in repo.

Possible enhancement would be to use `Type=notify` instead of `Type=simple` and wrap datum_gateway in a script that notifies systemd. But chose to stick with this simpler approach, as notification might better be implemented by datum_gateway itself.