### PR TITLE
Bugfix: Max possible template transactions inconsistent across functions

### DIFF
--- a/src/datum_blocktemplates.c
+++ b/src/datum_blocktemplates.c
@@ -253,9 +253,12 @@ T_DATUM_TEMPLATE_DATA *datum_gbt_parser(json_t *gbt) {
 	}
 	
 	tdata->txn_count = json_array_size(tx_array);
+	tdata->txn_data_offset = sizeof(T_DATUM_TEMPLATE_TXN)*tdata->txn_count;
 	if (tdata->txn_count > 0) {
-		tdata->txn_data_offset = sizeof(T_DATUM_TEMPLATE_TXN)*tdata->txn_count;
-		
+		if (tdata->txn_count > 16383) {
+			DLOG_WARN("DATUM Gateway does not support blocks with more than 16383 transactions! %d txns in template. Truncating template to 16383 transactions.", (int)tdata->txn_count);
+			tdata->txn_count = 16383;
+		}
 		for(i=0;i<tdata->txn_count;i++) {
 			json_t *tx = json_array_get(tx_array, i);
 			if (!tx) {

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -1845,6 +1845,7 @@ void stratum_job_merkle_root_calc(T_DATUM_STRATUM_JOB *s, unsigned char *coinbas
 }
 
 void stratum_calculate_merkle_branches(T_DATUM_STRATUM_JOB *s) {
+	// NOTE: This uses a static varaible for temp space. Do not call concurrently from multiple threads.
 	bool level_needs_dupe = false;
 	int current_level_size = 0, next_level_size = 0;
 	int q,i,j;
@@ -1856,12 +1857,20 @@ void stratum_calculate_merkle_branches(T_DATUM_STRATUM_JOB *s) {
 	const unsigned char (*current_level)[32];
 	unsigned char (*next_level)[32];
 	
-	// stratch RAM
-	unsigned char templist[8192][32];
+	// scratch RAM
+	static unsigned char templist[16384][32];
 	
-	current_level_size = s->block_template->txn_count+1;
+	// dev sanity check for thread concurrency
+	static int safety_check;
+	int marker = ++safety_check;
 	
-	if (!current_level_size) {
+	if (s->block_template->txn_count > 16383) {
+		DLOG_FATAL("BUG: stratum_calculate_merkle_branches does not support templates with more than 16383 transactions! %d transactions in template.",(int)s->block_template->txn_count);
+		panic_from_thread(__LINE__);
+		return;
+	}
+	
+	if (!s->block_template->txn_count) {
 		// no transactions
 		s->merklebranch_count = 0;
 		s->merklebranches_full[0] = '[';
@@ -1869,6 +1878,8 @@ void stratum_calculate_merkle_branches(T_DATUM_STRATUM_JOB *s) {
 		s->merklebranches_full[2] = 0;
 		return;
 	}
+	
+	current_level_size = s->block_template->txn_count+1;
 	
 	next_level = &templist[0];
 	current_level = next_level;
@@ -1947,6 +1958,11 @@ void stratum_calculate_merkle_branches(T_DATUM_STRATUM_JOB *s) {
 	}
 	s->merklebranches_full[j] = ']';
 	s->merklebranches_full[j+1] = 0;
+	
+	if (safety_check != marker) {
+		DLOG_FATAL("BUG: stratum_calculate_merkle_branches is NOT thread safe and appears to have been called concurrently!");
+		panic_from_thread(__LINE__);
+	}
 }
 
 void update_stratum_job(T_DATUM_TEMPLATE_DATA *block_template, bool new_block, int job_state) {


### PR DESCRIPTION
Bugfix: stratum_calculate_merkle_branches would choke at > 8192 transactions in a template. Moved the temp data to a static variable, and bumped the size to appropriately match the max template size possible.

Added some additional sanity checks.