### PR TITLE
Bugfix: Socket state can change between epoll and send

### DIFF
--- a/src/datum_gateway.c
+++ b/src/datum_gateway.c
@@ -132,6 +132,9 @@ int main(int argc, char **argv) {
 		exit(1);
 	}
 	
+	// Ignore SIGPIPE. This is instead handled gracefully by datum_sockets
+	signal(SIGPIPE, SIG_IGN);
+	
 	srand(time(NULL)); // Not used for anything secure, so this is fine.
 	
 	curl_global_init(CURL_GLOBAL_ALL);


### PR DESCRIPTION
Socket state can change and be improperly handled in the brief time between epoll and any send(...) from the application's client send buffer. Since this can lead to a SIGPIPE, despite the sockets being non-blocking, the gateway will exit without any descriptive error if this happens.

EPIPE is handled properly by existing datum_socket code.