### PR TITLE
Add datum process uptime

### DIFF
--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -141,13 +141,13 @@ void datum_api_var_STRATUM_HASHRATE_ESTIMATE(char *buffer, size_t buffer_size, c
 }
 void datum_api_var_DATUM_PROCESS_UPTIME(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
 	uint64_t uptime_seconds = get_process_uptime_seconds();
-	uint16_t days = uptime_seconds / (24 * 3600);
-	uint8_t hours = (uptime_seconds % (24 * 3600)) / 3600;
-	uint8_t minutes = (uptime_seconds % 3600) / 60;
-	uint8_t seconds = uptime_seconds % 60;
+	uint64_t days = uptime_seconds / (24 * 3600);
+	unsigned int hours = (uptime_seconds % (24 * 3600)) / 3600;
+	unsigned int minutes = (uptime_seconds % 3600) / 60;
+	unsigned int seconds = uptime_seconds % 60;
 	
 	if (days > 0) {
-		snprintf(buffer, buffer_size, "%u days, %u hours, %u minutes, %u seconds",
+		snprintf(buffer, buffer_size, "%lu days, %u hours, %u minutes, %u seconds",
 			days, hours, minutes, seconds);
 	} else if (hours > 0) {
 		snprintf(buffer, buffer_size, "%u hours, %u minutes, %u seconds",

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -147,7 +147,7 @@ void datum_api_var_DATUM_PROCESS_UPTIME(char *buffer, size_t buffer_size, const 
 	unsigned int seconds = uptime_seconds % 60;
 	
 	if (days > 0) {
-		snprintf(buffer, buffer_size, "%lu days, %u hours, %u minutes, %u seconds",
+		snprintf(buffer, buffer_size, "%"PRIu64" days, %u hours, %u minutes, %u seconds",
 			days, hours, minutes, seconds);
 	} else if (hours > 0) {
 		snprintf(buffer, buffer_size, "%u hours, %u minutes, %u seconds",

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -139,6 +139,26 @@ void datum_api_var_STRATUM_TOTAL_SUBSCRIPTIONS(char *buffer, size_t buffer_size,
 void datum_api_var_STRATUM_HASHRATE_ESTIMATE(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
 	snprintf(buffer, buffer_size, "%.2f Th/sec", vardata->STRATUM_HASHRATE_ESTIMATE);
 }
+void datum_api_var_DATUM_PROCESS_UPTIME(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
+	uint64_t uptime_seconds = get_process_uptime_seconds();
+	uint16_t days = uptime_seconds / (24 * 3600);
+	uint8_t hours = (uptime_seconds % (24 * 3600)) / 3600;
+	uint8_t minutes = (uptime_seconds % 3600) / 60;
+	uint8_t seconds = uptime_seconds % 60;
+	
+	if (days > 0) {
+		snprintf(buffer, buffer_size, "%u days, %u hours, %u minutes, %u seconds",
+			days, hours, minutes, seconds);
+	} else if (hours > 0) {
+		snprintf(buffer, buffer_size, "%u hours, %u minutes, %u seconds",
+			hours, minutes, seconds);
+	} else if (minutes > 0) {
+		snprintf(buffer, buffer_size, "%u minutes, %u seconds",
+			minutes, seconds);
+	} else {
+		snprintf(buffer, buffer_size, "%u seconds", seconds);
+	}
+}
 void datum_api_var_STRATUM_JOB_INFO(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
 	if (!vardata->sjob) return;
 	snprintf(buffer, buffer_size, "%s (%d) @ %.3f", vardata->sjob->job_id, vardata->sjob->global_index, (double)vardata->sjob->tsms / 1000.0);
@@ -196,6 +216,7 @@ DATUM_API_VarEntry var_entries[] = {
 	{"DATUM_MINER_TAG", datum_api_var_DATUM_MINER_TAG},
 	{"DATUM_POOL_DIFF", datum_api_var_DATUM_POOL_DIFF},
 	{"DATUM_POOL_PUBKEY", datum_api_var_DATUM_POOL_PUBKEY},
+	{"DATUM_PROCESS_UPTIME", datum_api_var_DATUM_PROCESS_UPTIME},
 	
 	{"STRATUM_ACTIVE_THREADS", datum_api_var_STRATUM_ACTIVE_THREADS},
 	{"STRATUM_TOTAL_CONNECTIONS", datum_api_var_STRATUM_TOTAL_CONNECTIONS},

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -85,7 +85,7 @@ uint64_t get_process_uptime_seconds() {
 
 void datum_utils_init(void) {
 	build_hex_lookup();
-	process_start_time = current_time_seconds();
+	process_start_time = monotonic_time_seconds();
 }
 
 #ifdef __GNUC__
@@ -127,9 +127,9 @@ unsigned char floorPoT(uint64_t x) {
 }
 #endif
 
-uint64_t current_time_seconds(void) {
+uint64_t monotonic_time_seconds(void) {
 	struct timespec ts;
-	clock_gettime(CLOCK_MONOTONIC, &ts); // SAFE from timezone changes
+	clock_gettime(CLOCK_MONOTONIC, &ts); // SAFE from system time changes (e.g., NTP adjustments, manual clock changes)
 	return (uint64_t)ts.tv_sec;
 }
 

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -55,6 +55,7 @@
 #include "datum_logger.h"
 
 volatile int panic_mode = 0;
+static uint64_t process_start_time = 0;
 
 void get_target_from_diff(unsigned char *result, uint64_t diff) {
 	uint64_t dividend_parts[4] = {0, 0, 0, 0x00000000FFFF0000};
@@ -76,8 +77,15 @@ void get_target_from_diff(unsigned char *result, uint64_t diff) {
 	}
 }
 
+uint64_t get_process_uptime_seconds() {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (uint64_t)ts.tv_sec - process_start_time;
+}
+
 void datum_utils_init(void) {
 	build_hex_lookup();
+	process_start_time = current_time_seconds();
 }
 
 #ifdef __GNUC__
@@ -118,6 +126,12 @@ unsigned char floorPoT(uint64_t x) {
 	return pos;
 }
 #endif
+
+uint64_t current_time_seconds(void) {
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts); // SAFE from timezone changes
+	return (uint64_t)ts.tv_sec;
+}
 
 uint64_t current_time_millis(void) {
 	struct timeval te;

--- a/src/datum_utils.h
+++ b/src/datum_utils.h
@@ -41,7 +41,7 @@
 #include "datum_logger.h"
 
 void datum_utils_init(void);
-uint64_t current_time_seconds(void);
+uint64_t monotonic_time_seconds(void);
 uint64_t current_time_millis(void);
 uint64_t current_time_micros(void);
 uint64_t get_process_uptime_seconds(void);

--- a/src/datum_utils.h
+++ b/src/datum_utils.h
@@ -41,8 +41,10 @@
 #include "datum_logger.h"
 
 void datum_utils_init(void);
+uint64_t current_time_seconds(void);
 uint64_t current_time_millis(void);
 uint64_t current_time_micros(void);
+uint64_t get_process_uptime_seconds(void);
 unsigned char hex2bin_uchar(const char *in);
 void build_hex_lookup(void);
 bool my_sha256(void *digest, const void *buffer, size_t length);

--- a/www/home.html
+++ b/www/home.html
@@ -100,6 +100,10 @@
 						<td class="label">Estimated Hashrate:</td>
 						<td>${STRATUM_HASHRATE_ESTIMATE}</td>
 					</tr>
+					<tr>
+						<td class="label">Process uptime:</td>
+						<td>${DATUM_PROCESS_UPTIME}</td>
+					</tr>
 				</table>
 			</div>
 		</div>

--- a/www/home.html
+++ b/www/home.html
@@ -78,6 +78,10 @@
 						<td class="label">Pool Pubkey:</td>
 						<td class="fixed-width">${DATUM_POOL_PUBKEY}</td>
 					</tr>
+					<tr>
+						<td class="label">Process uptime:</td>
+						<td>${DATUM_PROCESS_UPTIME}</td>
+					</tr>
 				</table>
 			</div>
 			
@@ -99,10 +103,6 @@
 					<tr>
 						<td class="label">Estimated Hashrate:</td>
 						<td>${STRATUM_HASHRATE_ESTIMATE}</td>
-					</tr>
-					<tr>
-						<td class="label">Process uptime:</td>
-						<td>${DATUM_PROCESS_UPTIME}</td>
 					</tr>
 				</table>
 			</div>


### PR DESCRIPTION
To address #70
To existing current_time_millis() and current_time_micros() I've added current_time_seconds()
It uses clock_gettime() to ensure local time changes (NTP, timezones) don't affect the uptime.
Perhaps will become useful in other places?

