### PR TITLE
Install README (and its diagram) to doc dir (incl. bugfix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.21)
 
 project(DATUM VERSION 0.2.3 LANGUAGES C)
 set(CMAKE_C_STANDARD 23)
+
+include(GNUInstallDirs)
+
 add_executable(datum_gateway
 	src/datum_api.c
 	src/datum_blocktemplates.c
@@ -97,3 +100,6 @@ target_compile_options(datum_gateway
 	${JANSSON_CFLAGS} ${JANSSON_CFLAGS_OTHER}
 	${SODIUM_CFLAGS} ${SODIUM_CFLAGS_OTHER}
 )
+
+install(FILES README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
+install(FILES doc/DATUM_recommended_setup-network_diagram.svg DESTINATION ${CMAKE_INSTALL_DOCDIR}/doc)

--- a/debian/rules
+++ b/debian/rules
@@ -3,3 +3,7 @@ export DH_VERBOSE = 1
 
 %:
 	dh $@
+
+override_dh_auto_configure:
+	dh_auto_configure -- \
+	-DCMAKE_INSTALL_DOCDIR=share/doc/datum-gateway


### PR DESCRIPTION
When merged into master, also fixes the "debian" doc dir used for the example JSON config.