### PR TITLE
stratum: Allow non-number JSON-RPC id values, up to 64 serialised characters long

### DIFF
--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -1692,16 +1692,16 @@ int datum_stratum_v1_socket_thread_client_cmd(T_DATUM_CLIENT_DATA *c, char *line
 		return -4;
 	}
 	
-	// enforce that id must be an integer.  might not be 100% to spec, but is sane and nothing known violates this.
-	// allowing arbitrary non-integer things here is a potential DoS vector.
-	if (!json_is_integer(id_obj)) {
-		json_decref(j);
-		return -4;
-	}
-	
 	// TODO: avoid round trip: just pass position/size into input string
 	id_ser = json_dumps(id_obj, JSON_COMPACT | JSON_ENCODE_ANY);
 	const size_t id_ser_len = strlen(id_ser);
+	
+	// limit length of serialised id to avoid potential DoS
+	if (id_ser_len > MAX_SERIALISED_JSONRPC_ID_LENGTH) {
+		free(id_ser);
+		json_decref(j);
+		return -4;
+	}
 	
 	if (!(params_obj = json_object_get(j, "params"))) {
 		free(id_ser);

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -101,6 +101,16 @@
 ////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////
 
+enum stratum_error_codes {
+	JSONRPC_METHOD_NOT_FOUND = -3,
+	STRATUM_SHARE_INVALID = 20,
+	STRATUM_JOB_NOT_FOUND = 21,
+	STRATUM_SHARE_DUPLICATE = 22,
+	STRATUM_SHARE_HIGHHASH = 23,
+	STRATUM_SHARE_BAD_WORKER = 24,
+	STRATUM_NOT_SUBSCRIBED = 25,
+};
+
 typedef struct {
 	char coinb1[STRATUM_COINBASE1_MAX_LEN];
 	char coinb2[STRATUM_COINBASE2_MAX_LEN];

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -46,6 +46,8 @@
 	#include "datum_blocktemplates.h"
 #endif
 
+#define MAX_SERIALISED_JSONRPC_ID_LENGTH 0x40
+
 #define MAX_STRATUM_JOBS 256
 
 #define MAX_COINBASE_TYPES 6


### PR DESCRIPTION
JSON-RPC allows "id" to be any type. Limit it to 64 characters (reserialised) to avoid potential DoS.

Built on #88 (and includes further refactoring)