### PR TITLE
Bugfix: Report correct maximum lengths in user error

### DIFF
--- a/src/datum_conf.c
+++ b/src/datum_conf.c
@@ -339,7 +339,7 @@ int datum_read_config(const char *conffile) {
 			DLOG_ERROR("Could not parse configuration option %s.%s.  Type should be %s", datum_config_options[i].category, datum_config_options[i].name, datum_conf_var_type_text[datum_config_options[i].var_type]);
 			return -1;
 		} else if (j == -2) {
-			DLOG_ERROR("Configuration option %s.%s exceeds maximum length of %d", datum_config_options[i].category, datum_config_options[i].name, datum_config_options[i].max_string_len);
+			DLOG_ERROR("Configuration option %s.%s exceeds maximum length of %d", datum_config_options[i].category, datum_config_options[i].name, datum_config_options[i].max_string_len - 1);
 			return -1;
 		}
 	}


### PR DESCRIPTION
The real limit is less 1 to leave room for a trailing null byte.