### PR TITLE
stratum: Workaround S21+ version-rolling bug

### DIFF
--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -1611,6 +1611,12 @@ void datum_stratum_fingerprint_by_UA(T_DATUM_MINER_DATA *m) {
 		return;
 	}
 	
+	if (strstr(m->useragent, "Antminer S21+/") == m->useragent) {
+		// Mar 12 firmware kills the connection if we send a version mask update before authentication completes (eg, before notify), and also doesn't need it anyway
+		m->extension_version_rolling_need_to_send_mask = false;
+		return;
+	}
+	
 	// the ePIC control boards can handle almost any size coinbase
 	// UA starts with: PowerPlay-BM/
 	if (strstr(m->useragent, "PowerPlay-BM/") == m->useragent) {

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -216,6 +216,7 @@ typedef struct {
 	char last_auth_username[192];
 	
 	bool extension_version_rolling;
+	bool extension_version_rolling_need_to_send_mask;
 	uint32_t extension_version_rolling_mask;
 	unsigned char extension_version_rolling_bits;
 	

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -582,7 +582,7 @@ bool strncpy_uachars(char *out, const char *in, size_t maxlen) {
 	out[0] = 0;
 	while((in[i] != 0) && (maxlen > 1)) {
 		c = in[i];
-		if (isalnum(c) || strchr(".-_=@, |/:<>';", c)) {
+		if (isalnum(c) || strchr(".+-_=@, |/:<>';", c)) {
 			out[j] = c;
 			j++;
 			maxlen--;

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -555,7 +555,7 @@ bool strncpy_workerchars(char *out, const char *in, size_t maxlen) {
 	out[0] = 0;
 	while((in[i] != 0) && (maxlen > 1)) {
 		c = in[i];
-		if ((isalnum(c)) || (c == '.') || (c == '-') || (c == '_') || (c == '=') || (c == '@') || (c == ',')) {
+		if (isalnum(c) || strchr(".-_=@,", c)) {
 			out[j] = c;
 			j++;
 			maxlen--;
@@ -582,7 +582,7 @@ bool strncpy_uachars(char *out, const char *in, size_t maxlen) {
 	out[0] = 0;
 	while((in[i] != 0) && (maxlen > 1)) {
 		c = in[i];
-		if ((isalnum(c)) || (c == '.') || (c == '-') || (c == '_') || (c == '=') || (c == '@') || (c == ',') || (c == ' ') || (c == '|') || (c == '/') || (c == '|') || (c == ':') || (c == '<') || (c == '>') || (c == '\'') || (c == ';')) {
+		if (isalnum(c) || strchr(".-_=@, |/:<>';", c)) {
 			out[j] = c;
 			j++;
 			maxlen--;


### PR DESCRIPTION
Defer `mining.set_version_mask` notification until after we have the client's user agent, and then don't send it at all if it's a S21+ (latest firmware has a bug that will drop the connection if it's received before authentication completes; and also it doesn't need it anyway)