### PR TITLE
CI: Use Docker to test Debian, AmazonLinux, Fedora, Alma, Oracle, Arch, and Clear Linux, with both GCC and Clang

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,11 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-22.04
+        config:
+          - cmake_args: "-DENABLE_API=ON"
+            extra_deps: "libmicrohttpd-dev"
+          - cmake_args: "-DENABLE_API=OFF"
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -23,10 +28,10 @@ jobs:
         run: mkdir -p build
         
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev libjansson-dev libmicrohttpd-dev libsodium-dev
+        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev libjansson-dev libsodium-dev ${{ matrix.config.extra_deps }}
       
       - name: Build DATUM Gateway
         run: |
           cd build
-          cmake ..
+          cmake .. ${{ matrix.config.cmake_args }}
           make -j$(nproc)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,11 @@ jobs:
           - ubuntu:22.04
           - debian:latest
           - debian:stable
+          - almalinux:latest
           - amazonlinux:latest
           - fedora:latest
+          - oraclelinux:9
+          - archlinux:latest
         config:
           - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=gcc"
             extra_deps: "gcc"
@@ -38,11 +41,19 @@ jobs:
               PACKAGES="git libc6-dev cmake libcurl4-openssl-dev libjansson-dev libsodium-dev pkgconf"
               PACKAGES_API="libmicrohttpd-dev"
               ;;
-            amazonlinux:*|fedora:*)
+            almalinux:*|amazonlinux:*|fedora:*|oraclelinux:*)
               INSTALL_CMD="dnf install -y"
+              [[ "${{ matrix.os }}" =~ ^almalinux: ]] && INSTALL_CMD="dnf install -y dnf-plugins-core && dnf config-manager --set-enabled crb && $INSTALL_CMD"
+              [[ "${{ matrix.os }}" =~ ^oraclelinux: ]] && INSTALL_CMD="dnf install -y dnf-plugins-core && dnf config-manager --set-enabled ol9_codeready_builder && $INSTALL_CMD"
+              [[ "${{ matrix.os }}" =~ ^(alma|oracle)linux: ]] && INSTALL_CMD="dnf install -y epel-release && $INSTALL_CMD"
               PACKAGES="git cmake libcurl-devel jansson-devel libsodium-devel pkgconf"
               PACKAGES_API="libmicrohttpd-devel"
               [[ "${{ matrix.config.cmake_args }}" =~ clang|gcc ]] || PACKAGES="$PACKAGES gcc"
+              ;;
+            archlinux:*)
+              INSTALL_CMD="pacman -Syu --noconfirm"
+              PACKAGES="git base-devel cmake curl jansson libsodium"
+              PACKAGES_API="libmicrohttpd"
               ;;
           esac
           PACKAGES="$PACKAGES ${{ matrix.config.extra_deps }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,13 @@ jobs:
           - ubuntu:22.04
           - debian:latest
           - debian:stable
+          - amazonlinux:latest
+          - fedora:latest
         config:
           - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=gcc"
-            extra_deps: "gcc libmicrohttpd-dev"
+            extra_deps: "gcc"
           - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=clang"
-            extra_deps: "clang libmicrohttpd-dev"
+            extra_deps: "clang"
           - cmake_args: "-DENABLE_API=OFF"
 
     runs-on: ubuntu-latest
@@ -30,9 +32,25 @@ jobs:
 
       - name: Build inside Docker
         run: |
+          case "${{ matrix.os }}" in
+            debian:*|ubuntu:*)
+              INSTALL_CMD="apt update && apt install -y"
+              PACKAGES="git libc6-dev cmake libcurl4-openssl-dev libjansson-dev libsodium-dev pkgconf"
+              PACKAGES_API="libmicrohttpd-dev"
+              ;;
+            amazonlinux:*|fedora:*)
+              INSTALL_CMD="dnf install -y"
+              PACKAGES="git cmake libcurl-devel jansson-devel libsodium-devel pkgconf"
+              PACKAGES_API="libmicrohttpd-devel"
+              [[ "${{ matrix.config.cmake_args }}" =~ clang|gcc ]] || PACKAGES="$PACKAGES gcc"
+              ;;
+          esac
+          PACKAGES="$PACKAGES ${{ matrix.config.extra_deps }}"
+          if [[ "${{ matrix.config.cmake_args }}" =~ ENABLE_API=ON ]]; then
+              PACKAGES="$PACKAGES $PACKAGES_API"
+          fi
           CMD="set -ex
-            apt update
-            apt install -y libc6-dev cmake libcurl4-openssl-dev libjansson-dev libsodium-dev pkgconf ${{ matrix.config.extra_deps }}
+            ${INSTALL_CMD} ${PACKAGES}
             git config --global --add safe.directory /workspace
             mkdir -p build
             cd build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,27 +11,31 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - ubuntu-22.04
+          - ubuntu:latest
+          - ubuntu:22.04
         config:
           - cmake_args: "-DENABLE_API=ON"
             extra_deps: "libmicrohttpd-dev"
           - cmake_args: "-DENABLE_API=OFF"
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Create build directory
-        run: mkdir -p build
-        
-      - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev libjansson-dev libsodium-dev ${{ matrix.config.extra_deps }}
-      
-      - name: Build DATUM Gateway
+      - name: Build inside Docker
         run: |
-          cd build
-          cmake .. ${{ matrix.config.cmake_args }}
-          make -j$(nproc)
+          CMD="set -ex
+            apt update
+            apt install -y build-essential cmake libcurl4-openssl-dev libjansson-dev libsodium-dev pkgconf ${{ matrix.config.extra_deps }}
+            git config --global --add safe.directory /workspace
+            mkdir -p build
+            cd build
+            cmake /workspace ${{ matrix.config.cmake_args }}
+            make -j\$(nproc)
+          "
+          docker run \
+            -v "${{ github.workspace }}:/workspace":ro \
+            "${{ matrix.os }}" \
+            /bin/sh -c "${CMD}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,11 +20,10 @@ jobs:
           - fedora:latest
           - oraclelinux:9
           - archlinux:latest
+          - clearlinux:latest
         config:
           - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=gcc"
-            extra_deps: "gcc"
           - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=clang"
-            extra_deps: "clang"
           - cmake_args: "-DENABLE_API=OFF"
 
     runs-on: ubuntu-latest
@@ -35,6 +34,8 @@ jobs:
 
       - name: Build inside Docker
         run: |
+          PACKAGES_CLANG='clang'
+          PACKAGES_GCC='gcc'
           case "${{ matrix.os }}" in
             debian:*|ubuntu:*)
               INSTALL_CMD="apt update && apt install -y"
@@ -55,10 +56,22 @@ jobs:
               PACKAGES="git base-devel cmake curl jansson libsodium"
               PACKAGES_API="libmicrohttpd"
               ;;
+            clearlinux:*)
+              INSTALL_CMD="swupd bundle-add"
+              PACKAGES="git c-basic devpkg-curl devpkg-jansson devpkg-libsodium"
+              PACKAGES_API="devpkg-libmicrohttpd"
+              PACKAGES_CLANG="llvm"
+              PACKAGES_GCC=''  # included in c-basic
+              ;;
           esac
           PACKAGES="$PACKAGES ${{ matrix.config.extra_deps }}"
           if [[ "${{ matrix.config.cmake_args }}" =~ ENABLE_API=ON ]]; then
               PACKAGES="$PACKAGES $PACKAGES_API"
+          fi
+          if [[ "${{ matrix.config.cmake_args }}" =~ CMAKE_C_COMPILER=gcc ]]; then
+              PACKAGES="$PACKAGES $PACKAGES_GCC"
+          elif [[ "${{ matrix.config.cmake_args }}" =~ CMAKE_C_COMPILER=clang ]]; then
+              PACKAGES="$PACKAGES $PACKAGES_CLANG"
           fi
           CMD="set -ex
             ${INSTALL_CMD} ${PACKAGES}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,8 @@ jobs:
         os:
           - ubuntu:latest
           - ubuntu:22.04
+          - debian:latest
+          - debian:stable
         config:
           - cmake_args: "-DENABLE_API=ON"
             extra_deps: "libmicrohttpd-dev"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,8 +16,10 @@ jobs:
           - debian:latest
           - debian:stable
         config:
-          - cmake_args: "-DENABLE_API=ON"
-            extra_deps: "libmicrohttpd-dev"
+          - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=gcc"
+            extra_deps: "gcc libmicrohttpd-dev"
+          - cmake_args: "-DENABLE_API=ON -DCMAKE_C_COMPILER=clang"
+            extra_deps: "clang libmicrohttpd-dev"
           - cmake_args: "-DENABLE_API=OFF"
 
     runs-on: ubuntu-latest
@@ -30,11 +32,11 @@ jobs:
         run: |
           CMD="set -ex
             apt update
-            apt install -y build-essential cmake libcurl4-openssl-dev libjansson-dev libsodium-dev pkgconf ${{ matrix.config.extra_deps }}
+            apt install -y libc6-dev cmake libcurl4-openssl-dev libjansson-dev libsodium-dev pkgconf ${{ matrix.config.extra_deps }}
             git config --global --add safe.directory /workspace
             mkdir -p build
             cd build
-            cmake /workspace ${{ matrix.config.cmake_args }}
+            cmake /workspace -DCMAKE_C_FLAGS='-Wall -Werror' ${{ matrix.config.cmake_args }}
             make -j\$(nproc)
           "
           docker run \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,7 @@ jobs:
             cd build
             cmake /workspace -DCMAKE_C_FLAGS='-Wall -Werror' ${{ matrix.config.cmake_args }}
             make -j\$(nproc)
+            ./datum_gateway --help
           "
           docker run \
             -v "${{ github.workspace }}:/workspace":ro \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,12 +49,18 @@ endif()
 pkg_check_modules(SODIUM REQUIRED libsodium)
 find_package(Threads REQUIRED)
 
-set(POW_LIBS "")
 include(CheckLibraryExists)
+include(CMakePushCheckState)
+cmake_push_check_state(RESET)
+string(APPEND CMAKE_REQUIRED_FLAGS -Wno-error)
+
+set(POW_LIBS "")
 check_library_exists(m pow "" LIBM)
 if(LIBM)
 	list(APPEND POW_LIBS "m")
 endif()
+
+cmake_pop_check_state()
 
 add_custom_target(generate_git_version
 	BYPRODUCTS ${PROJECT_BINARY_DIR}/git_version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,11 @@ cmake_minimum_required(VERSION 3.21)
 project(DATUM VERSION 0.2.3 LANGUAGES C)
 set(CMAKE_C_STANDARD 23)
 
+option(ENABLE_API "Build API support." ON)
+
 include(GNUInstallDirs)
 
 add_executable(datum_gateway
-	src/datum_api.c
 	src/datum_blocktemplates.c
 	src/datum_coinbaser.c
 	src/datum_conf.c
@@ -42,7 +43,9 @@ set(WEB_RESOURCES
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(CURL REQUIRED libcurl)
 pkg_check_modules(JANSSON REQUIRED jansson)
+if(ENABLE_API)
 pkg_check_modules(MICROHTTPD REQUIRED libmicrohttpd)
+endif()
 pkg_check_modules(SODIUM REQUIRED libsodium)
 find_package(Threads REQUIRED)
 
@@ -73,14 +76,12 @@ target_include_directories(datum_gateway
 	PRIVATE
 	$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
 	${CURL_INCLUDE_DIRS}
-	${MICROHTTPD_INCLUDE_DIRS}
 	${JANSSON_INCLUDE_DIRS}
 	${SODIUM_INCLUDE_DIRS}
 )
 target_link_directories(datum_gateway
 	PUBLIC
 	${CURL_LIBRARY_DIRS}
-	${MICROHTTPD_LIBRARY_DIRS}
 	${JANSSON_LIBRARY_DIRS}
 	${SODIUM_LIBRARY_DIRS}
 )
@@ -89,17 +90,26 @@ target_link_libraries(datum_gateway
 	${POW_LIBS}
 	Threads::Threads
 	${CURL_LIBRARIES} ${CURL_LDFLAGS} ${CURL_LDFLAGS_OTHER}
-	${MICROHTTPD_LIBRARIES} ${MICROHTTPD_LDFLAGS} ${MICROHTTPD_LDFLAGS_OTHER}
 	${JANSSON_LIBRARIES} ${JANSSON_LDFLAGS} ${JANSSON_LDFLAGS_OTHER}
 	${SODIUM_LIBRARIES} ${SODIUM_LDFLAGS} ${SODIUM_LDFLAGS_OTHER}
 )
 target_compile_options(datum_gateway
 	PUBLIC
 	${CURL_CFLAGS} ${CURL_CFLAGS_OTHER}
-	${MICROHTTPD_CFLAGS} ${MICROHTTPD_CFLAGS_OTHER}
 	${JANSSON_CFLAGS} ${JANSSON_CFLAGS_OTHER}
 	${SODIUM_CFLAGS} ${SODIUM_CFLAGS_OTHER}
 )
+
+if(ENABLE_API)
+	target_sources(datum_gateway PRIVATE src/datum_api.c)
+	target_include_directories(datum_gateway PRIVATE ${MICROHTTPD_INCLUDE_DIRS})
+	target_link_directories(datum_gateway PUBLIC ${MICROHTTPD_LIBRARY_DIRS})
+	target_link_libraries(datum_gateway PUBLIC ${MICROHTTPD_LIBRARIES} ${MICROHTTPD_LDFLAGS} ${MICROHTTPD_LDFLAGS_OTHER})
+	target_compile_options(datum_gateway PUBLIC
+		-DENABLE_API
+		${MICROHTTPD_CFLAGS} ${MICROHTTPD_CFLAGS_OTHER}
+	)
+endif()
 
 install(FILES README.md DESTINATION ${CMAKE_INSTALL_DOCDIR})
 install(FILES doc/DATUM_recommended_setup-network_diagram.svg DESTINATION ${CMAKE_INSTALL_DOCDIR}/doc)

--- a/src/datum_conf.c
+++ b/src/datum_conf.c
@@ -313,6 +313,11 @@ int datum_read_config(const char *conffile) {
 		datum_config.bitcoind_work_update_seconds = 120;
 	}
 	
+#ifndef ENABLE_API
+	if (datum_config.api_listen_port) {
+		DLOG_WARN("API is enabled in configuration, but this build was compiled without API support");
+	}
+#else
 	datum_config.api_admin_password_len = strlen(datum_config.api_admin_password);
 	if (datum_config.api_admin_password_len) {
 		static const char hash_tag[] = "DATUM Anti-CSRF Token";
@@ -326,6 +331,7 @@ int datum_read_config(const char *conffile) {
 		my_sha256(hash, data, data_sz);
 		hash2hex(hash, datum_config.api_csrf_token);
 	}
+#endif
 	
 	if (datum_config.stratum_v1_max_threads > MAX_THREADS) {
 		DLOG_FATAL("Maximum threads must be less than %d.", MAX_THREADS);

--- a/src/datum_gateway.c
+++ b/src/datum_gateway.c
@@ -161,11 +161,13 @@ int main(int argc, char **argv) {
 	}
 	last_datum_protocol_connect_tsms = current_time_millis();
 	
+#ifdef ENABLE_API
 	if (datum_api_init()) {
 		DLOG_FATAL("Error initializing API interface");
 		usleep(100000);
 		exit(1);
 	}
+#endif
 	
 	if (datum_coinbaser_init()) {
 		DLOG_FATAL("Error initializing coinbaser thread");


### PR DESCRIPTION
Based on #106 and #107