### PR TITLE
Improve datum_secure_strequals()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 project(DATUM VERSION 0.3.1 LANGUAGES C)
 
+enable_testing()
+
 # Enable C23 if supported, else fall back to C11 for compatibility
 if(CMAKE_VERSION VERSION_LESS "3.21")
     # Older CMake: C23 not recognized; use C11
@@ -158,3 +160,6 @@ if(NOT CMAKE_CROSSCOMPILING)
 		VERBATIM
 	)
 endif()
+
+add_subdirectory(tests)
+

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -805,7 +805,8 @@ bool datum_secure_strequals(const char *secret, const size_t secret_len, const c
 	const size_t guess_len = strlen(guess);
 	size_t acc = secret_len ^ guess_len;
 	for (size_t i = 0; i < guess_len; ++i) {
-		acc |= ((size_t)guess[i]) ^ ((size_t)secret[i % guess_len]);
+		size_t s = secret_len ? (size_t)secret[i % secret_len] : 0;
+		acc |= ((size_t)guess[i]) ^ s;
 	}
 	return !acc;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_executable(test_datum_utils
+    test_datum_utils.c
+    ${CMAKE_SOURCE_DIR}/src/datum_utils.c
+    ${CMAKE_SOURCE_DIR}/src/thirdparty_base58.c
+    ${CMAKE_SOURCE_DIR}/src/thirdparty_segwit_addr.c
+)
+
+# Link against libsodium and libm for datum_utils.c dependencies
+target_link_libraries(test_datum_utils PRIVATE
+    ${SODIUM_LIBRARIES} ${SODIUM_LDFLAGS} ${SODIUM_LDFLAGS_OTHER}
+    m
+)
+
+# Include headers from src directory
+target_include_directories(test_datum_utils PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}
+)
+
+add_test(NAME datum_utils_test COMMAND test_datum_utils)

--- a/tests/test_datum_utils.c
+++ b/tests/test_datum_utils.c
@@ -1,0 +1,35 @@
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+#include "datum_utils.h"
+
+/* Stub out logger dependency used by datum_utils.c */
+int datum_logger_queue_msg(const char *func, int level, const char *format, ...) {
+    (void)func; (void)level; (void)format;
+    return 0;
+}
+
+/* Provide dummy argv reference for datum_reexec */
+const char *datum_argv[] = { "test_datum_utils", NULL };
+
+
+int main(void) {
+    const char *secret = "abc";
+    size_t secret_len = strlen(secret);
+
+    /* equal strings */
+    assert(datum_secure_strequals(secret, secret_len, "abc"));
+
+    /* guess longer than secret */
+    assert(!datum_secure_strequals(secret, secret_len, "abcd"));
+
+    /* guess repeats secret but is longer */
+    assert(!datum_secure_strequals(secret, secret_len, "abcabc"));
+
+    /* zero-length secret matches only on empty guess */
+    assert(!datum_secure_strequals("", 0, "anything"));
+    assert(datum_secure_strequals("", 0, ""));
+
+    printf("All tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
`datum_secure_strequals()` will perform OOB operation on `secret` if it is shorter than `guess`
To fix it, modulo over `secret_len` instead of `guess_len`
To ensure we don't divide over 0 and empty `secret` still works, add a check that ensures the process remains constant-time.

First commit fixes the bug
Second commit adds a test, which might be a good starting point in general.