### PR TITLE
Announce jobs to the pool as they are created

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(datum_gateway
 	src/datum_jsonrpc.c
 	src/datum_logger.c
 	src/datum_protocol.c
+	src/datum_protocol_tests.c
 	src/datum_queue.c
 	src/datum_sockets.c
 	src/datum_stratum.c

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -863,6 +863,10 @@ void *datum_coinbaser_thread(void *ptr) {
 					pthread_rwlock_unlock(&need_coinbaser_rwlocks[sjob]);
 					need_coinbaser = false;
 				}
+				// Coinbases are final now, so the job can be announced.
+				if (s->is_datum_job) {
+					datum_protocol_announce_job(s->datum_job_idx);
+				}
 				DLOG_DEBUG("Generated and notified.");
 			}
 		}

--- a/src/datum_conf.c
+++ b/src/datum_conf.c
@@ -190,6 +190,8 @@ const T_DATUM_CONFIG_ITEM datum_config_options[] = {
 		.required = false, .ptr = &datum_config.datum_pooled_mining_only, 	.default_bool = true },
 	{ .var_type = DATUM_CONF_INT, 		.category = "datum", 		.name = "protocol_global_timeout",		.description = "If no valid messages are received from the DATUM server in this many seconds, give up and try to reconnect",
 		.required = false, .ptr = &datum_config.datum_protocol_global_timeout, 	.default_int = 60 },
+	{ .var_type = DATUM_CONF_BOOL, 		.category = "datum", 		.name = "announce_jobs",				.description = "Send each job's template data to the pool as the job is created, instead of only alongside the first share for that job. Uses more bandwidth, but lets the pool credit shares from miners that failed over directly to it",
+		.required = false, .ptr = &datum_config.datum_announce_jobs, 	.default_bool = false },
 };
 
 #define NUM_CONFIG_ITEMS (sizeof(datum_config_options) / sizeof(datum_config_options[0]))

--- a/src/datum_conf.h
+++ b/src/datum_conf.h
@@ -160,6 +160,7 @@ typedef struct {
 	char datum_pool_pubkey[1024];
 	int datum_protocol_global_timeout;
 	uint64_t datum_protocol_global_timeout_ms;
+	bool datum_announce_jobs;
 	
 	uint32_t prime_id;
 	unsigned char override_mining_pool_scriptsig[256];

--- a/src/datum_gateway.c
+++ b/src/datum_gateway.c
@@ -84,6 +84,7 @@ struct arguments {
 void datum_stratum_tests(void);
 void datum_conf_tests(void);
 void datum_utils_tests(void);
+void datum_protocol_tests(void);
 
 static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 	struct arguments *arguments = state->input;
@@ -106,6 +107,7 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state) {
 			datum_utils_tests();
 			datum_conf_tests();
 			datum_stratum_tests();
+			datum_protocol_tests();
 			exit(datum_test_failed);
 		default:
 			return ARGP_ERR_UNKNOWN;

--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -147,6 +147,13 @@ unsigned char datum_protocol_setup_new_job_idx(void *sx) {
 	
 	pthread_rwlock_unlock(&datum_jobs_rwlock);
 	
+	// If this job is still waiting on the coinbaser, its coinbases will be
+	// rebuilt out from under us, so leave the announcement to the coinbaser
+	// thread once the final ones exist.
+	if (!s->need_coinbaser) {
+		datum_protocol_announce_job(a);
+	}
+	
 	return a;
 }
 
@@ -1460,6 +1467,88 @@ int datum_protocol_pow(void *arg) {
 	}
 	datum_last_accepted_share_local_tsms = datum_protocol_mainloop_tsms;
 	return 0;
+}
+
+// Send the server a job's data up front rather than waiting for a share to
+// carry it. A miner that loses us fails over to the pool and submits the shares
+// it already found, which the pool can only credit if it can rebuild the job.
+void datum_protocol_announce_job(unsigned char datum_job_id) {
+	T_DATUM_STRATUM_JOB *sjob;
+	unsigned char *msg;
+	uint16_t coinbases_sent = 0;
+	bool sent_empty = false;
+	int i = 0, j, k;
+	
+	if (!datum_config.datum_announce_jobs) return;
+	if (datum_job_id >= MAX_DATUM_PROTOCOL_JOBS) return;
+	if (!datum_protocol_is_active()) return;
+	
+	msg = malloc(DATUM_PROTOCOL_ANNOUNCE_MSG_SIZE);
+	if (!msg) {
+		DLOG_ERROR("Could not allocate job announcement buffer!");
+		return;
+	}
+	
+	msg[i] = 0x28; i++; // announce job
+	msg[i] = datum_job_id; i++;
+	
+	pthread_rwlock_wrlock(&datum_jobs_rwlock);
+	
+	sjob = datum_jobs[datum_job_id].sjob;
+	if ((!sjob) || (!sjob->block_template) || datum_jobs[datum_job_id].server_has_merkle_branches) {
+		// no job, not ready, or the server already has everything it needs
+		pthread_rwlock_unlock(&datum_jobs_rwlock);
+		free(msg);
+		return;
+	}
+	
+	i = datum_protocol_append_job_data(msg, i, sjob, sjob->target_pot_index);
+	datum_jobs[datum_job_id].server_has_merkle_branches = true;
+	
+	// We don't know which coinbase variant the miner that fails over was
+	// working on, so the server needs every one we could have handed out.
+	for(k=0;k<MAX_COINBASE_TYPES;k++) {
+		if ((!sjob->coinbase[k].coinb1_len) && (!sjob->coinbase[k].coinb2_len)) continue;
+		i = datum_protocol_append_coinbase_data(msg, i, &sjob->coinbase[k], k);
+		datum_jobs[datum_job_id].server_has_coinbase[k] = true;
+		coinbases_sent |= (1 << k);
+	}
+	
+	if (sjob->subsidy_only_coinbase.coinb1_len || sjob->subsidy_only_coinbase.coinb2_len) {
+		i = datum_protocol_append_coinbase_data(msg, i, &sjob->subsidy_only_coinbase, 0xFF);
+		datum_jobs[datum_job_id].server_has_coinbase_empty = true;
+		sent_empty = true;
+	}
+	
+	pthread_rwlock_unlock(&datum_jobs_rwlock);
+	
+	// cap message
+	msg[i] = 0xFE; i++;
+	
+	// pad with some randomness
+	j = 1 + (rand() % 80);
+	memset(&msg[i], rand(), j);
+	i+=j;
+	
+	if (datum_protocol_mining_cmd(msg, i) < 1) {
+		// Undo the bookkeeping, or the share path would skip the job data too
+		// and every share against this job would be unverifiable.
+		pthread_rwlock_wrlock(&datum_jobs_rwlock);
+		if (datum_jobs[datum_job_id].sjob == sjob) {
+			datum_jobs[datum_job_id].server_has_merkle_branches = false;
+			for(k=0;k<MAX_COINBASE_TYPES;k++) {
+				if (coinbases_sent & (1 << k)) datum_jobs[datum_job_id].server_has_coinbase[k] = false;
+			}
+			if (sent_empty) datum_jobs[datum_job_id].server_has_coinbase_empty = false;
+		}
+		pthread_rwlock_unlock(&datum_jobs_rwlock);
+		DLOG_DEBUG("Could not announce job %d to server", (int)datum_job_id);
+		free(msg);
+		return;
+	}
+	
+	free(msg);
+	DLOG_DEBUG("Announced job %d to server (%d bytes)", (int)datum_job_id, i);
 }
 
 bool datum_protocol_thread_is_active(void) {

--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -1310,6 +1310,45 @@ int datum_protocol_pow_submit(
 	return datum_queue_add_item(&pow_queue, &pow);
 }
 
+// Appends the 0x01 sub-block: everything about a job except the coinbase.
+// Shared with job announcements so both paths encode identically.
+int datum_protocol_append_job_data(unsigned char *msg, int i, const T_DATUM_STRATUM_JOB *sjob, uint16_t target_byte_index) {
+	msg[i] = 0x01; i++;
+	memcpy(&msg[i], sjob->prevhash_bin, 32); i+=32;
+	pk_u16le(msg, i, target_byte_index); i += 2; // target byte location in coinb1
+	memcpy(&msg[i], &sjob->nbits_bin[0], sizeof(sjob->nbits_bin)); i += sizeof(sjob->nbits_bin); // nbits!
+	msg[i] = sjob->datum_coinbaser_id; i++;
+	pk_u32le(msg, i, sjob->height); i += 4;
+	pk_u64le(msg, i, sjob->coinbase_value); i += 8;
+	
+	pk_u32le(msg, i, sjob->block_template->txn_count); i += 4;
+	pk_u32le(msg, i, sjob->block_template->txn_total_weight); i += 4;
+	pk_u32le(msg, i, sjob->block_template->txn_total_size); i += 4;
+	pk_u32le(msg, i, sjob->block_template->txn_total_sigops); i += 4;
+	
+	msg[i] = sjob->merklebranch_count; i++;
+	
+	memcpy(&msg[i], &sjob->merklebranches_bin[0][0], sjob->merklebranch_count * 32);
+	i+=sjob->merklebranch_count * 32;
+	
+	return i;
+}
+
+// Appends the 0x02 sub-block: one coinbase variant. coinbase_id is 0xFF for the
+// subsidy only coinbase, otherwise the index into the job's coinbase array.
+int datum_protocol_append_coinbase_data(unsigned char *msg, int i, const T_DATUM_STRATUM_COINBASE *coinbase, unsigned char coinbase_id) {
+	msg[i] = 0x02; i++;
+	msg[i] = coinbase_id; i++;
+	pk_u16le(msg, i, coinbase->coinb1_len); i += 2;  // len1
+	pk_u16le(msg, i, coinbase->coinb2_len); i += 2;  // len2
+	memcpy(&msg[i], coinbase->coinb1_bin, coinbase->coinb1_len);
+	i+=coinbase->coinb1_len;
+	memcpy(&msg[i], coinbase->coinb2_bin, coinbase->coinb2_len);
+	i+=coinbase->coinb2_len;
+	
+	return i;
+}
+
 // {"params": ["mzjP9Hn7aqaCLM5pSgMSQzgs3gnxSFv91B", "662599770700", "f40c000000000000", "66259976", "48220d13", "00d30000"], "id": 182, "method": "mining.submit"}
 int datum_protocol_pow(void *arg) {
 	T_DATUM_PROTOCOL_POW *pow = arg;
@@ -1364,23 +1403,7 @@ int datum_protocol_pow(void *arg) {
 	if (!datum_jobs[pow->datum_job_id].server_has_merkle_branches) {
 		// we need to send the merkle branches with this job
 		// also send the prevblockhash
-		msg[i] = 0x01; i++;
-		memcpy(&msg[i], sjob->prevhash_bin, 32); i+=32;
-		pk_u16le(msg, i, pow->target_byte_index); i += 2; // target byte location in coinb1
-		memcpy(&msg[i], &sjob->nbits_bin[0], sizeof(sjob->nbits_bin)); i += sizeof(sjob->nbits_bin); // nbits!
-		msg[i] = sjob->datum_coinbaser_id; i++;
-		pk_u32le(msg, i, sjob->height); i += 4;
-		pk_u64le(msg, i, sjob->coinbase_value); i += 8;
-		
-		pk_u32le(msg, i, sjob->block_template->txn_count); i += 4;
-		pk_u32le(msg, i, sjob->block_template->txn_total_weight); i += 4;
-		pk_u32le(msg, i, sjob->block_template->txn_total_size); i += 4;
-		pk_u32le(msg, i, sjob->block_template->txn_total_sigops); i += 4;
-		
-		msg[i] = sjob->merklebranch_count; i++;
-		
-		memcpy(&msg[i], &sjob->merklebranches_bin[0][0], sjob->merklebranch_count * 32);
-		i+=sjob->merklebranch_count * 32;
+		i = datum_protocol_append_job_data(msg, i, sjob, pow->target_byte_index);
 		
 		// switch us to a write lock
 		pthread_rwlock_unlock(&datum_jobs_rwlock);
@@ -1391,14 +1414,8 @@ int datum_protocol_pow(void *arg) {
 	
 	if (pow->subsidy_only) {
 		if (!datum_jobs[pow->datum_job_id].server_has_coinbase_empty) {
-			msg[i] = 0x02; i++;
-			msg[i] = 0xFF; i++; // subsidy only coinbase! yes, I know we specified above in the flags as well
-			pk_u16le(msg, i, sjob->subsidy_only_coinbase.coinb1_len); i += 2;  // len1
-			pk_u16le(msg, i, sjob->subsidy_only_coinbase.coinb2_len); i += 2;  // len2
-			memcpy(&msg[i], sjob->subsidy_only_coinbase.coinb1_bin, sjob->subsidy_only_coinbase.coinb1_len);
-			i+=sjob->subsidy_only_coinbase.coinb1_len;
-			memcpy(&msg[i], sjob->subsidy_only_coinbase.coinb2_bin, sjob->subsidy_only_coinbase.coinb2_len);
-			i+=sjob->subsidy_only_coinbase.coinb2_len;
+			// subsidy only coinbase! yes, I know we specified above in the flags as well
+			i = datum_protocol_append_coinbase_data(msg, i, &sjob->subsidy_only_coinbase, 0xFF);
 			
 			if (!w) {
 				pthread_rwlock_unlock(&datum_jobs_rwlock);
@@ -1410,14 +1427,7 @@ int datum_protocol_pow(void *arg) {
 		}
 	} else {
 		if (!datum_jobs[pow->datum_job_id].server_has_coinbase[pow->coinbase_id]) {
-			msg[i] = 0x02; i++;
-			msg[i] = pow->coinbase_id; i++;
-			pk_u16le(msg, i, sjob->coinbase[pow->coinbase_id].coinb1_len); i += 2;  // len1
-			pk_u16le(msg, i, sjob->coinbase[pow->coinbase_id].coinb2_len); i += 2;  // len2
-			memcpy(&msg[i], sjob->coinbase[pow->coinbase_id].coinb1_bin, sjob->coinbase[pow->coinbase_id].coinb1_len);
-			i+=sjob->coinbase[pow->coinbase_id].coinb1_len;
-			memcpy(&msg[i], sjob->coinbase[pow->coinbase_id].coinb2_bin, sjob->coinbase[pow->coinbase_id].coinb2_len);
-			i+=sjob->coinbase[pow->coinbase_id].coinb2_len;
+			i = datum_protocol_append_coinbase_data(msg, i, &sjob->coinbase[pow->coinbase_id], pow->coinbase_id);
 			
 			if (!w) {
 				pthread_rwlock_unlock(&datum_jobs_rwlock);

--- a/src/datum_protocol.h
+++ b/src/datum_protocol.h
@@ -51,6 +51,12 @@
 #define DATUM_PROTOCOL_MAX_CMD_DATA_SIZE 4194304 // 2^22 - protocol limit!
 #define DATUM_PROTOCOL_BUFFER_SIZE (DATUM_PROTOCOL_MAX_CMD_DATA_SIZE*3)
 
+// Worst case job announcement: the job data sub-block carrying a full merkle
+// branch list, plus every coinbase variant and the subsidy only coinbase.
+// Padded for the sub-block headers, the message terminator, the random tail,
+// and the MAC that datum_protocol_mining_cmd appends when it encrypts in place.
+#define DATUM_PROTOCOL_ANNOUNCE_MSG_SIZE (2048 + ((MAX_COINBASE_TYPES + 1) * (8 + (STRATUM_COINBASE1_MAX_LEN>>1) + (STRATUM_COINBASE2_MAX_LEN>>1))) + 128 + crypto_box_MACBYTES)
+
 #define MAX_DATUM_CLIENT_EVENTS 32
 
 // Header is only XOR'd with a rotating key.  This is NOT 100% secure, and makes the cmd# and length of the handshake message decipherable.
@@ -137,6 +143,7 @@ int datum_protocol_pow_submit(
 bool datum_protocol_thread_is_active(void);
 void datum_protocol_start_connector(void);
 unsigned char datum_protocol_setup_new_job_idx(void *sx);
+void datum_protocol_announce_job(unsigned char datum_job_id);
 int datum_protocol_append_job_data(unsigned char *msg, int i, const T_DATUM_STRATUM_JOB *sjob, uint16_t target_byte_index);
 int datum_protocol_append_coinbase_data(unsigned char *msg, int i, const T_DATUM_STRATUM_COINBASE *coinbase, unsigned char coinbase_id);
 

--- a/src/datum_protocol.h
+++ b/src/datum_protocol.h
@@ -137,6 +137,8 @@ int datum_protocol_pow_submit(
 bool datum_protocol_thread_is_active(void);
 void datum_protocol_start_connector(void);
 unsigned char datum_protocol_setup_new_job_idx(void *sx);
+int datum_protocol_append_job_data(unsigned char *msg, int i, const T_DATUM_STRATUM_JOB *sjob, uint16_t target_byte_index);
+int datum_protocol_append_coinbase_data(unsigned char *msg, int i, const T_DATUM_STRATUM_COINBASE *coinbase, unsigned char coinbase_id);
 
 extern uint64_t datum_accepted_share_count;
 extern uint64_t datum_accepted_share_diff;

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -170,6 +170,49 @@ static void datum_protocol_tests_job_data_encoding(void) {
 	}
 }
 
+// An announcement carries the job data plus every populated coinbase, so the
+// buffer has to cover the largest job we can build.
+static void datum_protocol_tests_announce_buffer_bound(void) {
+	T_DATUM_STRATUM_JOB *job;
+	T_DATUM_TEMPLATE_DATA tmpl;
+	unsigned char *msg;
+	int i = 0, k;
+	
+	job = malloc(sizeof(T_DATUM_STRATUM_JOB));
+	msg = malloc(DATUM_PROTOCOL_ANNOUNCE_MSG_SIZE);
+	if ((!datum_test(job != NULL)) || (!datum_test(msg != NULL))) {
+		free(job);
+		free(msg);
+		return;
+	}
+	
+	datum_protocol_tests_fill_job(job, &tmpl);
+	
+	// Worst case: a full merkle branch list and every coinbase at max size.
+	job->merklebranch_count = 24;
+	for (k = 0; k < MAX_COINBASE_TYPES; k++) {
+		job->coinbase[k].coinb1_len = STRATUM_COINBASE1_MAX_LEN >> 1;
+		job->coinbase[k].coinb2_len = STRATUM_COINBASE2_MAX_LEN >> 1;
+	}
+	job->subsidy_only_coinbase.coinb1_len = STRATUM_COINBASE1_MAX_LEN >> 1;
+	job->subsidy_only_coinbase.coinb2_len = STRATUM_COINBASE2_MAX_LEN >> 1;
+	
+	msg[i] = 0x28; i++;
+	msg[i] = 0; i++;
+	i = datum_protocol_append_job_data(msg, i, job, job->target_pot_index);
+	for (k = 0; k < MAX_COINBASE_TYPES; k++) {
+		i = datum_protocol_append_coinbase_data(msg, i, &job->coinbase[k], k);
+	}
+	i = datum_protocol_append_coinbase_data(msg, i, &job->subsidy_only_coinbase, 0xFF);
+	msg[i] = 0xFE; i++;
+	
+	// Plus the random tail and the MAC that mining_cmd appends in place.
+	datum_test((size_t)(i + 80 + crypto_box_MACBYTES) <= (size_t)DATUM_PROTOCOL_ANNOUNCE_MSG_SIZE);
+	
+	free(job);
+	free(msg);
+}
+
 // A field can sit in the config struct without ever being wired into the
 // options table, in which case setting it in the config file silently does
 // nothing. Pin the option to the field it is supposed to drive.
@@ -186,5 +229,6 @@ static void datum_protocol_tests_announce_option(void) {
 
 void datum_protocol_tests(void) {
 	datum_protocol_tests_job_data_encoding();
+	datum_protocol_tests_announce_buffer_bound();
 	datum_protocol_tests_announce_option();
 }

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -37,6 +37,7 @@
 #include <string.h>
 
 #include "datum_blocktemplates.h"
+#include "datum_conf.h"
 #include "datum_protocol.h"
 #include "datum_stratum.h"
 #include "datum_utils.h"
@@ -169,6 +170,21 @@ static void datum_protocol_tests_job_data_encoding(void) {
 	}
 }
 
+// A field can sit in the config struct without ever being wired into the
+// options table, in which case setting it in the config file silently does
+// nothing. Pin the option to the field it is supposed to drive.
+static void datum_protocol_tests_announce_option(void) {
+	const T_DATUM_CONFIG_ITEM *opt = datum_config_get_option_info2("datum", "announce_jobs");
+
+	if (datum_test(opt != NULL)) {
+		datum_test(opt->var_type == DATUM_CONF_BOOL);
+		datum_test(opt->ptr == &datum_config.datum_announce_jobs);
+		// Sharing every template costs bandwidth, so this stays opt-in.
+		datum_test(opt->default_bool == false);
+	}
+}
+
 void datum_protocol_tests(void) {
 	datum_protocol_tests_job_data_encoding();
+	datum_protocol_tests_announce_option();
 }

--- a/src/datum_protocol_tests.c
+++ b/src/datum_protocol_tests.c
@@ -1,0 +1,174 @@
+/*
+ *
+ * DATUM Gateway
+ * Decentralized Alternative Templates for Universal Mining
+ *
+ * This file is part of OCEAN's Bitcoin mining decentralization
+ * project, DATUM.
+ *
+ * https://ocean.xyz
+ *
+ * ---
+ *
+ * Copyright (c) 2025 Bitcoin Ocean, LLC & Jason Hughes
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "datum_blocktemplates.h"
+#include "datum_protocol.h"
+#include "datum_stratum.h"
+#include "datum_utils.h"
+
+// Recognizable, non-repeating field values, so a mis-ordered or mis-sized
+// field shows up as a mismatch rather than a coincidence.
+static void datum_protocol_tests_fill_job(T_DATUM_STRATUM_JOB *job, T_DATUM_TEMPLATE_DATA *tmpl) {
+	int i, k;
+	
+	memset(job, 0, sizeof(T_DATUM_STRATUM_JOB));
+	memset(tmpl, 0, sizeof(T_DATUM_TEMPLATE_DATA));
+	
+	for (i = 0; i < 32; i++) job->prevhash_bin[i] = (unsigned char)(0x40 + i);
+	for (i = 0; i < 4; i++) job->nbits_bin[i] = (unsigned char)(0xE0 + i);
+	
+	job->target_pot_index = 0x1234;
+	job->datum_coinbaser_id = 0x5A;
+	job->height = 0x000A1B2C;
+	job->coinbase_value = 0x0102030405060708ULL;
+	
+	tmpl->txn_count = 0x11223344;
+	tmpl->txn_total_weight = 0x55667788;
+	tmpl->txn_total_size = 0x99AABBCC;
+	tmpl->txn_total_sigops = 0xDDEEFF00;
+	job->block_template = tmpl;
+	
+	job->merklebranch_count = 3;
+	for (k = 0; k < 3; k++) {
+		for (i = 0; i < 32; i++) job->merklebranches_bin[k][i] = (unsigned char)((k * 32) + i);
+	}
+	
+	for (k = 0; k < MAX_COINBASE_TYPES; k++) {
+		job->coinbase[k].coinb1_len = 4 + k;
+		job->coinbase[k].coinb2_len = 7 + k;
+		for (i = 0; i < job->coinbase[k].coinb1_len; i++) job->coinbase[k].coinb1_bin[i] = (unsigned char)(0xA0 + (k * 16) + i);
+		for (i = 0; i < job->coinbase[k].coinb2_len; i++) job->coinbase[k].coinb2_bin[i] = (unsigned char)(0xC0 + (k * 16) + i);
+	}
+	
+	job->subsidy_only_coinbase.coinb1_len = 5;
+	job->subsidy_only_coinbase.coinb2_len = 6;
+	for (i = 0; i < 5; i++) job->subsidy_only_coinbase.coinb1_bin[i] = (unsigned char)(0x10 + i);
+	for (i = 0; i < 6; i++) job->subsidy_only_coinbase.coinb2_bin[i] = (unsigned char)(0x20 + i);
+}
+
+// The reference encoding, written longhand as the share path built it before
+// datum_protocol_append_job_data was factored out. The pool parses these
+// bytes, so drift here is a wire protocol break.
+static int datum_protocol_tests_reference_job_data(unsigned char *msg, int i, const T_DATUM_STRATUM_JOB *sjob, uint16_t target_byte_index) {
+	msg[i] = 0x01; i++;
+	memcpy(&msg[i], sjob->prevhash_bin, 32); i+=32;
+	pk_u16le(msg, i, target_byte_index); i += 2;
+	memcpy(&msg[i], &sjob->nbits_bin[0], sizeof(sjob->nbits_bin)); i += sizeof(sjob->nbits_bin);
+	msg[i] = sjob->datum_coinbaser_id; i++;
+	pk_u32le(msg, i, sjob->height); i += 4;
+	pk_u64le(msg, i, sjob->coinbase_value); i += 8;
+	
+	pk_u32le(msg, i, sjob->block_template->txn_count); i += 4;
+	pk_u32le(msg, i, sjob->block_template->txn_total_weight); i += 4;
+	pk_u32le(msg, i, sjob->block_template->txn_total_size); i += 4;
+	pk_u32le(msg, i, sjob->block_template->txn_total_sigops); i += 4;
+	
+	msg[i] = sjob->merklebranch_count; i++;
+	
+	memcpy(&msg[i], &sjob->merklebranches_bin[0][0], sjob->merklebranch_count * 32);
+	i+=sjob->merklebranch_count * 32;
+	
+	return i;
+}
+
+static int datum_protocol_tests_reference_coinbase_data(unsigned char *msg, int i, const T_DATUM_STRATUM_COINBASE *coinbase, unsigned char coinbase_id) {
+	msg[i] = 0x02; i++;
+	msg[i] = coinbase_id; i++;
+	pk_u16le(msg, i, coinbase->coinb1_len); i += 2;
+	pk_u16le(msg, i, coinbase->coinb2_len); i += 2;
+	memcpy(&msg[i], coinbase->coinb1_bin, coinbase->coinb1_len);
+	i+=coinbase->coinb1_len;
+	memcpy(&msg[i], coinbase->coinb2_bin, coinbase->coinb2_len);
+	i+=coinbase->coinb2_len;
+	
+	return i;
+}
+
+// The share path and the announce path must hand the pool the same bytes for
+// the same job, and those bytes must match what shipped before the refactor.
+static void datum_protocol_tests_job_data_encoding(void) {
+	T_DATUM_STRATUM_JOB job;
+	T_DATUM_TEMPLATE_DATA tmpl;
+	unsigned char got[4096], want[4096];
+	int got_len, want_len, k;
+	
+	datum_protocol_tests_fill_job(&job, &tmpl);
+	
+	memset(got, 0, sizeof(got));
+	memset(want, 0, sizeof(want));
+	
+	got_len = datum_protocol_append_job_data(got, 0, &job, job.target_pot_index);
+	want_len = datum_protocol_tests_reference_job_data(want, 0, &job, job.target_pot_index);
+	
+	// 1 tag + 32 prevhash + 2 target index + 4 nbits + 1 coinbaser id + 4 height
+	// + 8 value + 16 template counters + 1 branch count + 3 branches
+	datum_test(want_len == 69 + (3 * 32));
+	if (datum_test(got_len == want_len)) {
+		datum_test(memcmp(got, want, want_len) == 0);
+	}
+	
+	// Offsetting the write must not change the encoding, only where it lands.
+	memset(got, 0, sizeof(got));
+	datum_test(datum_protocol_append_job_data(got, 7, &job, job.target_pot_index) == want_len + 7);
+	datum_test(memcmp(&got[7], want, want_len) == 0);
+	
+	for (k = 0; k < MAX_COINBASE_TYPES; k++) {
+		memset(got, 0, sizeof(got));
+		memset(want, 0, sizeof(want));
+		got_len = datum_protocol_append_coinbase_data(got, 0, &job.coinbase[k], k);
+		want_len = datum_protocol_tests_reference_coinbase_data(want, 0, &job.coinbase[k], k);
+		datum_test(want_len == 6 + job.coinbase[k].coinb1_len + job.coinbase[k].coinb2_len);
+		if (datum_test(got_len == want_len)) {
+			datum_test(memcmp(got, want, want_len) == 0);
+		}
+	}
+	
+	// The subsidy only coinbase rides the same sub-block under id 0xFF.
+	memset(got, 0, sizeof(got));
+	memset(want, 0, sizeof(want));
+	got_len = datum_protocol_append_coinbase_data(got, 0, &job.subsidy_only_coinbase, 0xFF);
+	want_len = datum_protocol_tests_reference_coinbase_data(want, 0, &job.subsidy_only_coinbase, 0xFF);
+	datum_test(got[1] == 0xFF);
+	if (datum_test(got_len == want_len)) {
+		datum_test(memcmp(got, want, want_len) == 0);
+	}
+}
+
+void datum_protocol_tests(void) {
+	datum_protocol_tests_job_data_encoding();
+}


### PR DESCRIPTION
> Being reworked. Per feedback below, the server boots clients that send job data without
> following shares, so the push approach here is wrong. Switching to a pool-initiated pull
> over the existing `0x50` namespace. The encoder refactor in the first commit stays.

Towards #86. Pushes a job's template data to the pool when the job is created, rather than only when the first share for that job arrives.

The pool already gets this data, just lazily: `datum_protocol_pow` embeds the `0x01` sub-block (prevhash, nbits, height, merkle branches) and `0x02` sub-block (coinbase) alongside the first share that needs them, tracked by `server_has_merkle_branches` / `server_has_coinbase[]`. That breaks down in the #86 case, where a miner loses its gateway, fails over to the pool, and submits shares it already found. The pool never saw a share for that job, so it cannot rebuild it and cannot credit them.

This sends the same `0x01` / `0x02` sub-blocks the pool already parses, under a new sub-command `0x28`, before any share exists. The encoders are factored out of `datum_protocol_pow` and shared so the two paths cannot drift, with tests asserting byte-identical output to the previous inline encoding. It reuses the existing `server_has_*` flags, so an announced job is not re-sent with the first share, and the flags roll back if the send fails.

Announcement waits on the coinbaser for jobs that need one, since `datum_coinbaser_thread` rebuilds `s->coinbase[]` in place after the job is published. All coinbase variants are sent, because the gateway cannot know which one the failing-over miner was using.

New option `datum.announce_jobs`, off by default, since sharing every template costs bandwidth.

This is only the gateway side. No pool implements `0x28`, so these bytes have never been parsed by a receiver, and no live run has reached the announce path. The failover leg needs the firmware changes #86 mentions.

Questions before building further on this:

- Is `0x28` the right shape, or would you rather the pool pulled a template through the existing `0x50` namespace when it actually has a failover share to settle? A pull would also avoid sending every coinbase variant.
- After a reconnect the `server_has_*` flags reset, but live jobs are not re-announced until the next job is created. Worth closing that gap?
- How should the pool tie a directly submitted share back to a gateway job? The miner submits its own extranonce to the pool, and that mapping is not something this addresses.
