### PR TITLE
Display aggregated stratum client share stats in solo (non-pooled) mining mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,9 +272,10 @@ blocknotify=wget -q -O /dev/null http://datum-gateway-host-ip:7152/NOTIFY
 
 - By default, if the connection with the pool is lost and fails to reconnect, the Gateway will disconnect all stratum clients. This way miners can use their built-in failover and switch to non-DATUM mining, or an alternate/backup Gateway.
 - Accepted/rejected share counts on mining hardware may not perfectly match with the pool. The delta may vary depending on the Gateway's configuration. This is because shares are first accepted or rejected as valid for your local template based on your local node, and then again accepted or rejected based on the pool's requirements, latency to the pool (stale work), latency between your node and the network (stale work), etc.  Stratum v1 has no mechanism to report back to the miner that previously accepted work is now rejected, and it doesn't make sense to wait for the pool before responding, either.
-- **Share Statistics**: The "Shares Accepted" and "Shares Rejected" counters on the web dashboard behave differently depending on the mining mode:
-  - **Pooled Mining Mode** (`pooled_mining_only: true`): Shows shares accepted/rejected by the pool
-  - **Solo Mining Mode** (`pooled_mining_only: false`): Shows shares accepted/rejected from your connected stratum miners, providing visibility into your mining activity even when not connected to a pool
+ - **Share Statistics**: The "Shares Accepted" and "Shares Rejected" counters on the web dashboard prefer pool statistics when a pool is configured/active, and otherwise show local stratum client statistics:
+  - When a DATUM pool connection is active (or configured), the dashboard shows shares accepted/rejected by the pool (pool perspective)
+  - When no pool connection is active, the dashboard shows shares accepted/rejected from connected stratum miners (local perspective)
+  - In all modes, block templates are constructed from your own Bitcoin node
 
 **Most importantly**, please note that this is currently a public **BETA** release. While best efforts have been made to ensure this software is as stable and as useful as possible, you may still encounter issues.
 

--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ blocknotify=wget -q -O /dev/null http://datum-gateway-host-ip:7152/NOTIFY
 
 - By default, if the connection with the pool is lost and fails to reconnect, the Gateway will disconnect all stratum clients. This way miners can use their built-in failover and switch to non-DATUM mining, or an alternate/backup Gateway.
 - Accepted/rejected share counts on mining hardware may not perfectly match with the pool. The delta may vary depending on the Gateway's configuration. This is because shares are first accepted or rejected as valid for your local template based on your local node, and then again accepted or rejected based on the pool's requirements, latency to the pool (stale work), latency between your node and the network (stale work), etc.  Stratum v1 has no mechanism to report back to the miner that previously accepted work is now rejected, and it doesn't make sense to wait for the pool before responding, either.
+- **Share Statistics**: The "Shares Accepted" and "Shares Rejected" counters on the web dashboard behave differently depending on the mining mode:
+  - **Pooled Mining Mode** (`pooled_mining_only: true`): Shows shares accepted/rejected by the pool
+  - **Solo Mining Mode** (`pooled_mining_only: false`): Shows shares accepted/rejected from your connected stratum miners, providing visibility into your mining activity even when not connected to a pool
 
 **Most importantly**, please note that this is currently a public **BETA** release. While best efforts have been made to ensure this software is as stable and as useful as possible, you may still encounter issues.
 

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -89,22 +89,16 @@ static void html_leading_zeros(char * const buffer, const size_t buffer_size, co
 }
 
 void datum_api_var_DATUM_SHARES_ACCEPTED(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
-	// Show pool shares when in pooled mode, stratum client shares when in solo mode
-	// This allows solo miners to see their actual mining activity instead of zeros
-	if (datum_config.datum_pooled_mining_only) {
-		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_accepted_share_count, (unsigned long long)datum_accepted_share_diff);
-	} else {
-		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)stratum_client_accepted_share_count, (unsigned long long)stratum_client_accepted_share_diff);
-	}
+    // Prefer pool stats when a pool is configured/active; otherwise show local stratum client stats
+    // Pool considered active if the DATUM protocol is active, or configured if pool host is set
+    // Dashboard always renders datum_* counters; when no pool is active, we mirror local stats into datum_* at submit time
+    (void)vardata;
+    snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_accepted_share_count, (unsigned long long)datum_accepted_share_diff);
 }
 void datum_api_var_DATUM_SHARES_REJECTED(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
-	// Show pool shares when in pooled mode, stratum client shares when in solo mode
-	// This allows solo miners to see their actual mining activity instead of zeros
-	if (datum_config.datum_pooled_mining_only) {
-		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_rejected_share_count, (unsigned long long)datum_rejected_share_diff);
-	} else {
-		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)stratum_client_rejected_share_count, (unsigned long long)stratum_client_rejected_share_diff);
-	}
+    // Prefer pool stats when a pool is configured/active; otherwise show local stratum client stats
+    (void)vardata;
+    snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_rejected_share_count, (unsigned long long)datum_rejected_share_diff);
 }
 void datum_api_var_DATUM_CONNECTION_STATUS(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
 	const char *colour = "lime";

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -89,10 +89,22 @@ static void html_leading_zeros(char * const buffer, const size_t buffer_size, co
 }
 
 void datum_api_var_DATUM_SHARES_ACCEPTED(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
-	snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_accepted_share_count, (unsigned long long)datum_accepted_share_diff);
+	// Show pool shares when in pooled mode, stratum client shares when in solo mode
+	// This allows solo miners to see their actual mining activity instead of zeros
+	if (datum_config.datum_pooled_mining_only) {
+		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_accepted_share_count, (unsigned long long)datum_accepted_share_diff);
+	} else {
+		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)stratum_client_accepted_share_count, (unsigned long long)stratum_client_accepted_share_diff);
+	}
 }
 void datum_api_var_DATUM_SHARES_REJECTED(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
-	snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_rejected_share_count, (unsigned long long)datum_rejected_share_diff);
+	// Show pool shares when in pooled mode, stratum client shares when in solo mode
+	// This allows solo miners to see their actual mining activity instead of zeros
+	if (datum_config.datum_pooled_mining_only) {
+		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)datum_rejected_share_count, (unsigned long long)datum_rejected_share_diff);
+	} else {
+		snprintf(buffer, buffer_size, "%llu  (%llu diff)", (unsigned long long)stratum_client_rejected_share_count, (unsigned long long)stratum_client_rejected_share_diff);
+	}
 }
 void datum_api_var_DATUM_CONNECTION_STATUS(char *buffer, size_t buffer_size, const T_DATUM_API_DASH_VARS *vardata) {
 	const char *colour = "lime";

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -76,15 +76,6 @@ bool stratum_latest_empty_ready_for_full = 0;
 uint64_t stratum_latest_empty_job_index = 0;
 uint64_t stratum_latest_empty_sent_count = 0;
 
-// Global counters for total shares from stratum clients
-// These counters track all share submissions from connected miners,
-// providing accurate statistics for solo mining operations where pool
-// share counters would remain at zero.
-uint64_t stratum_client_accepted_share_count = 0;
-uint64_t stratum_client_accepted_share_diff = 0;
-uint64_t stratum_client_rejected_share_count = 0;
-uint64_t stratum_client_rejected_share_diff = 0;
-
 pthread_rwlock_t need_coinbaser_rwlocks[MAX_STRATUM_JOBS];
 bool need_coinbaser_rwlocks_init_done = false;
 
@@ -1277,8 +1268,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 		send_rejected_stale_block(c, id);
 		m->share_count_rejected++;
 		m->share_diff_rejected += job_diff;
-		__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-		__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+			__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+			__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		}
 		return 0;
 	}
 	
@@ -1288,8 +1281,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 		send_rejected_time_too_old(c, id);
 		m->share_count_rejected++;
 		m->share_diff_rejected += job_diff;
-		__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-		__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+			__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+			__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		}
 		return 0;
 	}
 	
@@ -1297,8 +1292,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 		send_rejected_time_too_new(c, id);
 		m->share_count_rejected++;
 		m->share_diff_rejected += job_diff;
-		__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-		__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+			__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+			__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		}
 		return 0;
 	}
 	
@@ -1310,8 +1307,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 			send_rejected_high_hash_error(c, id);
 			m->share_count_rejected++;
 			m->share_diff_rejected += job_diff;
-			__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-			__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+			if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+				__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+				__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+			}
 			return 0;
 		}
 	} else {
@@ -1321,8 +1320,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 			send_rejected_high_hash_error(c, id);
 			m->share_count_rejected++;
 			m->share_diff_rejected += job_diff;
-			__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-			__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+			if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+				__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+				__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+			}
 			return 0;
 		}
 	}
@@ -1333,8 +1334,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 		send_rejected_stale(c, id);
 		m->share_count_rejected++;
 		m->share_diff_rejected += job_diff;
-		__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-		__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+			__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+			__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		}
 		return 0;
 	}
 	
@@ -1344,8 +1347,10 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 		send_rejected_duplicate(c, id);
 		m->share_count_rejected++;
 		m->share_diff_rejected += job_diff;
-		__atomic_add_fetch(&stratum_client_rejected_share_count, 1, __ATOMIC_RELAXED);
-		__atomic_add_fetch(&stratum_client_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+			__atomic_add_fetch(&datum_rejected_share_count, 1, __ATOMIC_RELAXED);
+			__atomic_add_fetch(&datum_rejected_share_diff, job_diff, __ATOMIC_RELAXED);
+		}
 		return 0;
 	}
 	
@@ -1365,9 +1370,11 @@ int client_mining_submit(T_DATUM_CLIENT_DATA *c, uint64_t id, json_t *params_obj
 	m->share_diff_accepted += job_diff;
 	m->share_count_accepted++;
 	
-	// update global stratum client totals (used for solo mining display)
-	__atomic_add_fetch(&stratum_client_accepted_share_count, 1, __ATOMIC_RELAXED);
-	__atomic_add_fetch(&stratum_client_accepted_share_diff, job_diff, __ATOMIC_RELAXED);
+	// Mirror to pool counters when no pool is active
+	if (!(datum_protocol_is_active() || (datum_config.datum_pool_host[0] != '\0'))) {
+		__atomic_add_fetch(&datum_accepted_share_count, 1, __ATOMIC_RELAXED);
+		__atomic_add_fetch(&datum_accepted_share_diff, job_diff, __ATOMIC_RELAXED);
+	}
 	
 	// update since-snap totals
 	m->share_count_since_snap++;

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -290,4 +290,14 @@ extern T_DATUM_SOCKET_APP *global_stratum_app;
 extern pthread_rwlock_t need_coinbaser_rwlocks[MAX_STRATUM_JOBS];
 extern bool need_coinbaser_rwlocks_init_done;
 
+// Global counters for total shares from stratum clients
+// These track all shares submitted by miners connected to the stratum server,
+// regardless of whether they're forwarded to a pool or used for solo mining.
+// In solo mining mode, these counters are displayed on the web dashboard instead
+// of the pool share counters, providing visibility into miner activity.
+extern uint64_t stratum_client_accepted_share_count;
+extern uint64_t stratum_client_accepted_share_diff;
+extern uint64_t stratum_client_rejected_share_count;
+extern uint64_t stratum_client_rejected_share_diff;
+
 #endif

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -290,14 +290,4 @@ extern T_DATUM_SOCKET_APP *global_stratum_app;
 extern pthread_rwlock_t need_coinbaser_rwlocks[MAX_STRATUM_JOBS];
 extern bool need_coinbaser_rwlocks_init_done;
 
-// Global counters for total shares from stratum clients
-// These track all shares submitted by miners connected to the stratum server,
-// regardless of whether they're forwarded to a pool or used for solo mining.
-// In solo mining mode, these counters are displayed on the web dashboard instead
-// of the pool share counters, providing visibility into miner activity.
-extern uint64_t stratum_client_accepted_share_count;
-extern uint64_t stratum_client_accepted_share_diff;
-extern uint64_t stratum_client_rejected_share_count;
-extern uint64_t stratum_client_rejected_share_diff;
-
 #endif


### PR DESCRIPTION
## Problem

When running DATUM Gateway without a pool configured, the "Shares Accepted" and "Shares Rejected" counters on the web dashboard always display `0`, as there is no pool to track shares against. This makes it impossible to monitor mining activity via the gateway when not connected to a pool.

## Community Discussion

https://x.com/innerhat/status/1979236476652261388

I'm not the only one who can see the confusion around the feature, and I can do something to help.

## Solution

This PR mirrors stratum client share submissions into the existing pool share counters when no pool is active/configured, allowing miners to see their mining activity on the dashboard regardless of pool configuration.

**Dashboard behavior:**
- **Pool configured/active**: Shows pool share statistics *(existing behavior)*
- **No pool configured/active**: Shows local stratum client share statistics mirrored into pool counters *(new behavior)*

Note: DATUM always constructs block templates from your own Bitcoin node in all configurations. The difference is whether shares are accounted for by a pool or tracked locally.

## Changes

### Modified Files
- `src/datum_stratum.c` - Added mirroring logic to increment pool counters when no pool is active
- `src/datum_stratum.h` - Removed stratum_client_* counter declarations
- `src/datum_api.c` - Simplified dashboard display logic
- `README.md` - Updated documentation to clarify share statistics behavior

### Modifications
- When no pool is active/configured, mirror local share submissions into existing `datum_accepted_share_count`/`datum_rejected_share_count` counters
- Use `datum_protocol_is_active()` and `datum_pool_host` to determine if pool is active
- Track all share acceptance/rejection paths (stale-prevblock, time-too-old/new, high-hash, stale-by-time, duplicate)
- Update README to clarify that dashboard prefers pool stats when pool is active, local stats when not

## Performance Impact

### Atomic Operations Cost
| Operation | CPU Cycles | Notes |
|-----------|------------|-------|
| `__atomic_add_fetch()` (RELAXED) | ~5-10 | Per atomic operation |
| 2 atomic ops per share | ~10-20 | Count + diff increment |
| Regular addition | ~1 | Baseline comparison |
| **Added overhead** | **~18** | **Per share (no pool only)** |

### Context
- SHA256 double hash (share validation): **~100,000+ cycles**
- Network latency: **millions of cycles**
- Our overhead: **0.01-0.02% of validation time**

### Real-World Impact
| Aspect | Impact |
|--------|--------|
| Template delivery | **NO CHANGE** (separate thread) |
| Share latency | **+0.01-0.02%** (unmeasurable, no pool only) |
| Mining efficiency | **NO CHANGE** |
| Block propagation | **NO CHANGE** |

### Conclusion
The atomic increments only execute when no pool is active, adding a few nanoseconds per submitted share on the gateway. Template generation and delivery are completely unaffected (separate thread).

## Testing

Tested with:
- DATUM Gateway without pool configured
- Connected ASIC miner submitting shares
- Share counters increment correctly for accepted shares
- Web dashboard displays accurate statistics
- No performance degradation observed

Could not test:
- Share counters for rejected shares (stale, duplicate, high hash, time errors), but logic is implemented for all rejection paths

## Benefits

- Miners can now monitor their mining activity in real-time regardless of pool configuration
- Better visibility into miner performance and configuration issues
- Reuses existing pool counter variables (no new state)
- No behavior change when pool is configured
- Zero measurable performance impact