### PR TITLE
CI: Drop discontinued Clear Linux

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,6 @@ jobs:
           - oraclelinux:9
           - alpine:latest
           - archlinux:latest
-          - clearlinux:latest
           - gentoo/stage3:musl-hardened
           - gentoo/stage3:hardened
         config:
@@ -80,13 +79,6 @@ jobs:
               INSTALL_CMD="pacman -Syu --noconfirm"
               PACKAGES="git base-devel cmake curl jansson libsodium"
               PACKAGES_API="libmicrohttpd"
-              ;;
-            clearlinux:*)
-              INSTALL_CMD="swupd bundle-add"
-              PACKAGES="git c-basic devpkg-curl devpkg-jansson devpkg-libsodium"
-              PACKAGES_API="devpkg-libmicrohttpd"
-              PACKAGES_CLANG="llvm"
-              PACKAGES_GCC=''  # included in c-basic
               ;;
             gentoo/*)
               PKG_CACHE_DIR='/var/cache/binpkgs'


### PR DESCRIPTION
Intel pulled the plug on their Clear Linux distro: https://community.clearlinux.org/t/all-good-things-come-to-an-end-shutting-down-clear-linux-os/10716
