### PR TITLE
Add extra debug logging for payout address, script hex in coinbase txn, etc

### DIFF
--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -356,7 +356,6 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 	} else {
 		// No pool
 		s->pool_addr_script_len = addr_2_output_script(datum_config.mining_pool_address, &s->pool_addr_script[0], 64);
-		DLOG_DEBUG("Using configured payout address: %s (script len %d)", datum_config.mining_pool_address, s->pool_addr_script_len);
 		s->is_datum_job = false;
 	}
 	if (!s->pool_addr_script_len) {
@@ -457,6 +456,14 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
 	// lock time
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "00000000");
+
+	// adding additional debugging detail
+	DLOG_DEBUG("Raw coinb1 prefix hex (input + tags): %s", s->coinbase[0].coinb1);
+    DLOG_DEBUG("Raw coinb2 outputs hex (payout + witness + locktime): %s", s->coinbase[0].coinb2);
+    DLOG_DEBUG("Coinbase payout address: %s", datum_config.mining_pool_address);
+    DLOG_DEBUG("Coinbase payout value: %" PRIu64 " sats (%.8f BTC)", s->coinbase_value, (double)s->coinbase_value / 100000000.0);
+    DLOG_DEBUG("Coinbase primary tag: %s", datum_config.mining_coinbase_tag_primary);
+    DLOG_DEBUG("Coinbase secondary tag: %s", datum_config.mining_coinbase_tag_secondary);
 
 	if (new_block) {
 		// Append the subsidy-only payout to the subsidy_only_coinbase

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -65,13 +65,13 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 	int k, m, i;
 	int excess;
 	bool datum_active = false;
-	
+
 	// let's figure out our coinbase tags w/BIP34 height
 	i = append_UNum_hex(height, &cb[0]);
 	cb_input_sz += i>>1;
-	
+
 	datum_active = datum_protocol_is_active();
-	
+
 	// Handle coinbase tagging
 	// The first push after the height should be:
 	// PUSHBYTES X, Primary tag, 0x0F, Secondary tag, 0x0F, Tertiary tag, 0x00
@@ -89,7 +89,7 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 			k--;
 		}
 	}
-	
+
 	if (k > MAX_COINBASE_TAG_SPACE) {
 		// something still needs truncating
 		excess = k - MAX_COINBASE_TAG_SPACE;
@@ -105,14 +105,14 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 			}
 		}
 	}
-	
+
 	if (k > MAX_COINBASE_TAG_SPACE) {
 		// one tag should never exceed 64 bytes, so we're going to panic here.
 		DLOG_FATAL("Could not fit coinbase primary tag alone somehow. This is probably a bug. Panicking. :(");
 		panic_from_thread(__LINE__);
 		sleep(1000000);
 	}
-	
+
 	if (k > 0) {
 		// ok, we have one or more coinbase tags with a total len of k
 		if (k <= 75) {
@@ -123,7 +123,7 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 			uchar_to_hex(&cb[i], 0x4C); i+=2; cb_input_sz++;
 			uchar_to_hex(&cb[i], (unsigned char)k); i+=2; cb_input_sz++;
 		}
-		
+
 		if (tag_len[0]) {
 			if (datum_active) {
 				for(m=0;m<tag_len[0];m++) {
@@ -145,7 +145,7 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 				uchar_to_hex(&cb[i], 0x0F); i+=2; cb_input_sz++;
 			}
 		}
-		
+
 		if (tag_len[1]) {
 			for(m=0;m<tag_len[1];m++) {
 				uchar_to_hex(&cb[i], (unsigned char)datum_config.mining_coinbase_tag_secondary[m]); i+=2; cb_input_sz++;
@@ -157,7 +157,7 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 		uchar_to_hex(&cb[i], 0x01); i+=2; cb_input_sz++;
 		uchar_to_hex(&cb[i], 0x00); i+=2; cb_input_sz++;
 	}
-	
+
 	// append the coinbase unique ID tag
 	if ((datum_config.prime_id == 0) && (!datum_active)) {
 		uchar_to_hex(&cb[i], 0x03); i+=2; cb_input_sz++;
@@ -176,14 +176,14 @@ int generate_coinbase_input(int height, char *cb, int *target_pot_index) {
 		uchar_to_hex(&cb[i], ((datum_config.prime_id>>16)&0xFF)); i+=2; cb_input_sz++;
 		uchar_to_hex(&cb[i], ((datum_config.prime_id>>24)&0xFF)); i+=2; cb_input_sz++;
 	}
-	
+
 	return cb_input_sz;
 }
 
 void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s, int coinbase_index, int remaining_size, bool space_for_en_in_coinbase, int *cb1idx, int *cb2idx, bool special_coinb1) {
 	// This function finishes off the stratum coinb1+coinb2 using the available outputs in the job and other flags specified.
 	// it does not attempt to maximize coinb1's size to any specific size
-	
+
 	int i, j, k, m, i2 = 0, c1cnt = 0;
 	uint64_t mval = 0;
 	bool c1full = false;
@@ -201,7 +201,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 	mval = 0;
 	// technically an output script could be > 0x4B, meaning an extra byte would be eaten here... but that's not currently the standard
 	// this needs to match the loop lower in this function, as the count will get thrown off if it does not.
-	
+
 	// TODO: Enforce max sigops! Note: This is not currently enforced in eloipool, either, so punting for now and will monitor network stats to determine priority.
 	for(k=0;k<s->available_coinbase_outputs_count;k++) {
 		if (((s->available_coinbase_outputs[k].output_script_len+9) <= i) && ((mval + s->available_coinbase_outputs[k].value_sats) <= s->coinbase_value))  {
@@ -211,7 +211,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 			} else {
 				c1full = true;
 			}
-			
+
 			i -= (s->available_coinbase_outputs[k].output_script_len+9);
 			m++;
 			mval += s->available_coinbase_outputs[k].value_sats;
@@ -219,7 +219,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 			if (mval >= s->coinbase_value) break;
 		}
 	}
-	
+
 	// "m" outputs fit
 	if (space_for_en_in_coinbase) {
 		// we'll start the empty coinb2 with the "sequence"
@@ -230,23 +230,23 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 	} else {
 		m+=3;
 		cb1idx[coinbase_index] += append_bitcoin_varint_hex(m, &s->coinbase[coinbase_index].coinb1[cb1idx[coinbase_index]]); // extranonce, us, witness commit, and "m" outputs
-		
+
 		if (!special_coinb1) {
 			// append extranonce op_return
 			cb1idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb1[cb1idx[coinbase_index]], "0000000000000000106a0e%04" PRIx16, s->enprefix);
 			en_done = true;
 		}
 	}
-	
+
 	// append "m" payouts. find them the same way we did before
 	mval = 0;
 	for(k=0;k<s->available_coinbase_outputs_count;k++) {
 		if (((s->available_coinbase_outputs[k].output_script_len+9) <= j) && ((mval + s->available_coinbase_outputs[k].value_sats) <= s->coinbase_value)) {
 			j -= (s->available_coinbase_outputs[k].output_script_len+9);
 			m--;
-			
+
 			mval += s->available_coinbase_outputs[k].value_sats;
-			
+
 			if ((special_coinb1) && (k < c1cnt)) {
 				// put in coinb1
 				cb1idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb1[cb1idx[coinbase_index]], "%016llx", (unsigned long long)__builtin_bswap64(s->available_coinbase_outputs[k].value_sats)); // TODO: Profile a faster way to do this
@@ -261,7 +261,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 					cb1idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb1[cb1idx[coinbase_index]], "0000000000000000106a0e%04" PRIx16, s->enprefix);
 					en_done = true;
 				}
-				
+
 				// put in coinb2
 				cb2idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]], "%016llx", (unsigned long long)__builtin_bswap64(s->available_coinbase_outputs[k].value_sats)); // TODO: Profile a faster way to do this
 				cb2idx[coinbase_index] += append_bitcoin_varint_hex(s->available_coinbase_outputs[k].output_script_len, &s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]]); // Append script length
@@ -275,17 +275,17 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 			if (mval >= s->coinbase_value) break;
 		}
 	}
-	
+
 	// this should never happen, but...
 	if (mval > s->coinbase_value) {
 		DLOG_ERROR("Attempting to pay more than we have available in the generation txn! --- %"PRIu64" sats available, %"PRIu64" sats to miners", s->coinbase_value, mval);
 	}
-	
+
 	if ((!space_for_en_in_coinbase) && (!en_done)) {
 		cb1idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb1[cb1idx[coinbase_index]], "0000000000000000106a0e%04" PRIx16, s->enprefix);
 		en_done = true;
 	}
-	
+
 	if (s->coinbase_value > mval) {
 		// append our payout output value and script, since there are leftover funds
 		cb2idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]], "%016llx", (unsigned long long)__builtin_bswap64(s->coinbase_value - mval)); // TODO: Profile a faster way to do this
@@ -302,7 +302,7 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 		// This is quite unlikely in practice, but, just in case let's make this a prunable OP_RETURN
 		cb2idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]], "0000000000000000036a0100"); // TODO: Is a naked OP_RETURN without any bytes after safe?  Above TODO is probably better than investigating.
 	}
-	
+
 	// witness commit output costs 46 bytes
 	// append the default_witness_commitment
 	cb2idx[coinbase_index] += sprintf(&s->coinbase[coinbase_index].coinb2[cb2idx[coinbase_index]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
@@ -312,26 +312,26 @@ void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s
 
 int datum_stratum_coinbase_fit_to_template(int max_sz, int fixed_bytes, T_DATUM_STRATUM_JOB *s) {
 	int j,i,msz1;
-	
+
 	i = fixed_bytes + max_sz;
 	msz1 = max_sz+fixed_bytes;
-	
+
 	if ((i+s->block_template->txn_total_size+85+36) > s->block_template->sizelimit) {
 		j = s->block_template->sizelimit - (s->block_template->txn_total_size+85+36) - fixed_bytes;
 		if (j < 0) return 0;
 		msz1 = j;
 	}
-	
+
 	if (((i<<2)+s->block_template->txn_total_weight+340+36) > s->block_template->weightlimit) {
 		j = ((s->block_template->weightlimit - (s->block_template->txn_total_weight+340+36))>>2) - fixed_bytes;
 		if (j < 0) return 0;
 		msz1 = j;
 	}
-	
+
 	if (msz1 < 0) {
 		msz1 = 0;
 	}
-	
+
 	if (msz1 < (max_sz - fixed_bytes)) {
 		return msz1;
 	} else {
@@ -347,7 +347,7 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 	int cb1idx[1] = { 0 };
 	int cb2idx[1] = { 0 };
 	int target_pot_index;
-	
+
 	if (datum_protocol_is_active()) {
 		// DATUM
 		s->pool_addr_script_len = datum_config.override_mining_pool_scriptsig_len;
@@ -356,6 +356,7 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 	} else {
 		// No pool
 		s->pool_addr_script_len = addr_2_output_script(datum_config.mining_pool_address, &s->pool_addr_script[0], 64);
+		DLOG_DEBUG("Using configured payout address: %s (script len %d)", datum_config.mining_pool_address, s->pool_addr_script_len);
 		s->is_datum_job = false;
 	}
 	if (!s->pool_addr_script_len) {
@@ -366,17 +367,17 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 	j = strlen(cbstart_hex);
 	memcpy(&s->coinbase[0].coinb1[0], cbstart_hex, j);
 	cb1idx[0] = j;
-	
+
 	cb_input_sz = generate_coinbase_input(s->height, &cb[0], &target_pot_index);
 	i = cb_input_sz << 1;
-	
+
 	// null terminate... probably not needed
 	cb[i] = 0;
-	
+
 	if (cb_input_sz <= 85) {
 		space_for_en_in_coinbase = true;
 	}
-	
+
 	if (space_for_en_in_coinbase) {
 		cb1idx[0] += append_bitcoin_varint_hex(cb_input_sz+15, &s->coinbase[0].coinb1[cb1idx[0]]); // 15 bytes for extranonce+uid push + data
 	} else {
@@ -385,7 +386,7 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 	memcpy(&s->coinbase[0].coinb1[cb1idx[0]], &cb[0], cb_input_sz*2);
 	s->target_pot_index = target_pot_index + (cb1idx[0]>>1); // adjust for placement in the txn. always safe for all types, since the varint will always be 1 byte.
 	cb1idx[0] += cb_input_sz*2;
-	
+
 	if (space_for_en_in_coinbase) {
 		// if we are doing extranonce in the coinbase, then this is ALMOST the end of coinbase1
 		// we need a PUSH 14 and our enprefix in the coinbase
@@ -398,9 +399,9 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 		pk_u64le(s->coinbase[0].coinb1, cb1idx[0], 0x6666666666666666ULL);  // "ffffffff"
 		cb1idx[0] += 8;
 	}
-	
+
 	s->coinbase[0].coinb1[cb1idx[0]] = 0;
-	
+
 	/////////////////////////////
 	// 0 / EMPTY
 	// empty should be easy. lets start there
@@ -409,7 +410,7 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 		pk_u64le(s->coinbase[0].coinb2, 0, 0x6666666666666666ULL);  // "ffffffff"
 		cb2idx[0] = 8;
 		cb2idx[0] += append_bitcoin_varint_hex(2, &s->coinbase[0].coinb2[cb2idx[0]]); // us and witness commit
-		
+
 		if (new_block) {
 			// copy the beginning to the subsidy-only
 			memcpy(&s->subsidy_only_coinbase.coinb1[0], &s->coinbase[0].coinb1[0], cb1idx[0]);
@@ -422,10 +423,10 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 			j = cb1idx[0];
 		}
 		cb1idx[0] += append_bitcoin_varint_hex(3, &s->coinbase[0].coinb1[cb1idx[0]]); // extranonce, us, and witness commit
-		
+
 		// append extranonce op_return
 		cb1idx[0] += sprintf(&s->coinbase[0].coinb1[cb1idx[0]], "0000000000000000106a0e%04" PRIx16, s->enprefix);
-		
+
 		if (new_block) {
 			// copy the beginning to the subsidy-only
 			memcpy(&s->subsidy_only_coinbase.coinb1[0], &s->coinbase[0].coinb1[0], cb1idx[0]);
@@ -434,41 +435,41 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 		}
 	}
 	// finish off "empty" coinbase
-	
+
 	// append our payout output value and script
 	if (new_block) {
 		j = cb2idx[0];
 	}
-	
+
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "%016llx", (unsigned long long)__builtin_bswap64(s->coinbase_value)); // TODO: Profile a faster way to do this
 	cb2idx[0] += append_bitcoin_varint_hex(s->pool_addr_script_len, &s->coinbase[0].coinb2[cb2idx[0]]); // Append script length
 	for(i=0;i<s->pool_addr_script_len;i++) {
 		uchar_to_hex(&s->coinbase[0].coinb2[cb2idx[0]], s->pool_addr_script[i]);
 		cb2idx[0]+=2;
 	}
-	
+
 	if (new_block) {
 		k = cb2idx[0];
 	}
-	
+
 	// witness commit output costs 46 bytes
 	// append the default_witness_commitment
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
 	// lock time
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "00000000");
-	
+
 	if (new_block) {
 		// Append the subsidy-only payout to the subsidy_only_coinbase
 		sprintf(&s->subsidy_only_coinbase.coinb2[j], "%016llx", (unsigned long long)__builtin_bswap64(block_reward(s->height))); // subsidy calc for height
 		memcpy(&s->subsidy_only_coinbase.coinb2[j+16], &s->coinbase[0].coinb2[j+16], k-j-16);
 		sprintf(&s->subsidy_only_coinbase.coinb2[k], "00000000");
 	}
-	
+
 	// End of 0 / Empty
 	//////////////////////////////
-	
+
 	// prep binary versions of the coinbase for speeding up later
-	
+
 	i = strlen(s->coinbase[0].coinb1);
 	s->coinbase[0].coinb1_len = 0;
 	for(j=0;j<i;j+=2) {
@@ -481,7 +482,7 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 		s->coinbase[0].coinb2_bin[j>>1] = hex2bin_uchar(&s->coinbase[0].coinb2[j]);
 		s->coinbase[0].coinb2_len++;
 	}
-	
+
 	if (new_block) {
 		i = strlen(s->subsidy_only_coinbase.coinb1);
 		s->subsidy_only_coinbase.coinb1_len = 0;
@@ -500,25 +501,25 @@ void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool ne
 
 void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_only) {
 	// Account for available vsize, sigops, size, weight, etc
-	
+
 	// Note:
 	// With a minimum payout of 10 TBC, the largest likely coinbase as of height 840000 is around 16 KB if we paid every miner the minimum to a long address type.
 	// This seems highly unlikely.  16KB is more than sufficient.
-	
+
 	int i, j, k;
 	char cb[300];
 	int target_pot_index;
 	int cb_input_sz = 0;
-	
+
 	bool space_for_en_in_coinbase = false;
-	
+
 	int cb1idx[MAX_COINBASE_TYPES] = { 0,0,0,0,0,0 };
 	int cb2idx[MAX_COINBASE_TYPES] = { 0,0,0,0,0,0 };
-	
+
 	int cb_req_sz[MAX_COINBASE_TYPES] = { 0,0,0,0,0 };
-	
+
 	////////////////
-	
+
 	// Initial mainnet coinbaser
 	if (datum_protocol_is_active()) {
 		// DATUM
@@ -538,28 +539,28 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		DLOG_FATAL("Could not generate output script for pool addr! Perhaps invalid? This is bad.");
 		panic_from_thread(__LINE__);
 	}
-	
+
 	// copy beginning of the generation txn to the appropriate outputs
 	j = strlen(cbstart_hex);
 	for(i=0;i<MAX_COINBASE_TYPES;i++) {
 		memcpy(&s->coinbase[i].coinb1[0], cbstart_hex, j);
 		cb1idx[i] = j;
 	}
-	
+
 	cb_input_sz = generate_coinbase_input(s->height, &cb[0], &target_pot_index);
 	s->target_pot_index = target_pot_index;
 	i = cb_input_sz << 1;
-	
+
 	// null terminate... probably not needed
 	cb[i] = 0;
-	
+
 	// do we have space in the coinbase for the extranonce for types that can do it this way?
 	// we need 1 byte for the push, 2 for the enprefix, 4 for en1 and 8 for en2 = 15 bytes
 	// coinbase max is 100
 	if (cb_input_sz <= 85) {
 		space_for_en_in_coinbase = true;
 	}
-	
+
 	// multiple coinbase options
 	// 0 = "empty" --- just pays pool addr, and possibly TIDES data.  extranonce in coinbase if fits, or in first output if not.
 	// 1 = "nicehash" --- roughly 500 bytes total... smaller than antminer... has nothing before the extranonce OP_RETURN (or no extranonce OP_RETURN if enough space in the coinbase)
@@ -567,7 +568,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 	// 3 = "whatsminer" --- max 6500 bytes tested.  does not need the extranonce OP_RETURN unless there's no space in the coinbase itself after tags
 	// 4 = "huge" --- max 16kB --- this is probably the most we should reasonably attempt to do in the coinbase... something like 380 to 530 outputs, depending on the type of output
 	// 5 = "antminer2" --- max 2250 bytes --- latest S21s appear to support this
-	
+
 	// only type 2 *needs* the OP_RETURN extranonce, unless the coinbase itself is too long
 	// set the len, and copy over the rest of the coinbase
 	for(i=0;i<MAX_COINBASE_TYPES;i++) {
@@ -581,7 +582,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		// little silly to set this multiple times, but it's fine for consistency.
 		s->target_pot_index = target_pot_index + (cb1idx[i]>>1);
 		cb1idx[i] += cb_input_sz*2;
-		
+
 		if ((i!=2) && (space_for_en_in_coinbase)) {
 			// if we are doing extranonce in the coinbase, then this is ALMOST the end of coinbase1
 			// we need a PUSH 14 and our enprefix in the coinbase
@@ -594,19 +595,19 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 			pk_u64le(s->coinbase[i].coinb1, cb1idx[i], 0x6666666666666666ULL);  // "ffffffff"
 			cb1idx[i] += 8;
 		}
-		
+
 		s->coinbase[i].coinb1[cb1idx[i]] = 0;
 	}
-	
+
 	// extranonce ends up at the end of coinb1
 	// for the antminer hack coinbaser, we want to cram an output or two in coinb1, which is tricky
 	// would be much easier to just always use the OP_RETURN, but that's wasteful when not needed as it wastes 10 bytes (wastes 8 bytes for the value, 2 for the OP_RETURN and the PUSH...)
 	// if extranonce in the coinbase, then we start coinb2 with the "sequence"
 	// if extranonce not in the coinbase, then we already tacked the "sequence" on to coinb1 immediately
-	
+
 	// we need to know the output count for each type so we can figure out what to stuff in each one
 	// this may be a bit wasteful, but needs to be done.  only needs to happen once per work update, and only when doing non-empty.
-	
+
 	/////////////////////////////
 	// 0 / EMPTY
 	// empty should be easy. lets start there
@@ -615,7 +616,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		pk_u64le(s->coinbase[0].coinb2, 0, 0x6666666666666666ULL);  // "ffffffff"
 		cb2idx[0] = 8;
 		cb2idx[0] += append_bitcoin_varint_hex(2, &s->coinbase[0].coinb2[cb2idx[0]]); // us and witness commit
-		
+
 		if (empty_only) {
 			// copy the beginning to the subsidy-only
 			memcpy(&s->subsidy_only_coinbase.coinb1[0], &s->coinbase[0].coinb1[0], cb1idx[0]);
@@ -628,10 +629,10 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 			j = cb1idx[0];
 		}
 		cb1idx[0] += append_bitcoin_varint_hex(3, &s->coinbase[0].coinb1[cb1idx[0]]); // extranonce, us, and witness commit
-		
+
 		// append extranonce op_return
 		cb1idx[0] += sprintf(&s->coinbase[0].coinb1[cb1idx[0]], "0000000000000000106a0e%04" PRIx16, s->enprefix);
-		
+
 		if (empty_only) {
 			// copy the beginning to the subsidy-only
 			memcpy(&s->subsidy_only_coinbase.coinb1[0], &s->coinbase[0].coinb1[0], cb1idx[0]);
@@ -640,39 +641,39 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		}
 	}
 	// finish off "empty" coinbase
-	
+
 	// append our payout output value and script
 	if (empty_only) {
 		j = cb2idx[0];
 	}
-	
+
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "%016llx", (unsigned long long)__builtin_bswap64(s->coinbase_value)); // TODO: Profile a faster way to do this
 	cb2idx[0] += append_bitcoin_varint_hex(s->pool_addr_script_len, &s->coinbase[0].coinb2[cb2idx[0]]); // Append script length
 	for(i=0;i<s->pool_addr_script_len;i++) {
 		uchar_to_hex(&s->coinbase[0].coinb2[cb2idx[0]], s->pool_addr_script[i]);
 		cb2idx[0]+=2;
 	}
-	
+
 	if (empty_only) {
 		k = cb2idx[0];
 	}
-	
+
 	// witness commit output costs 46 bytes
 	// append the default_witness_commitment
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "0000000000000000%2.2x%s", (unsigned int)strlen(s->block_template->default_witness_commitment)>>1, s->block_template->default_witness_commitment);
 	// lock time
 	cb2idx[0] += sprintf(&s->coinbase[0].coinb2[cb2idx[0]], "00000000");
-	
+
 	if (empty_only) {
 		// Append the subsidy-only payout to the subsidy_only_coinbase
 		sprintf(&s->subsidy_only_coinbase.coinb2[j], "%016llx", (unsigned long long)__builtin_bswap64(block_reward(s->height))); // subsidy calc for height
 		memcpy(&s->subsidy_only_coinbase.coinb2[j+16], &s->coinbase[0].coinb2[j+16], k-j-16);
 		sprintf(&s->subsidy_only_coinbase.coinb2[k], "00000000");
 	}
-	
+
 	// End of 0 / Empty
 	//////////////////////////////
-	
+
 	if (empty_only) {
 		// copy empty coinbaser to the others
 		for (i=1;i<MAX_COINBASE_TYPES;i++) {
@@ -682,7 +683,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 	} else {
 		// ok, let's figure out how much space, if any, we have for miner payout outputs
 		// we first need to figure out how much space we are using for each type after required data, so let's do that
-		
+
 		// witness output = 46 bytes
 		// pool output = pool_addr_script_len + 9
 		// coinbase itself = cb_input_sz
@@ -697,35 +698,35 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 		// total static bytes = 46+9+1+41+4+3+4+15 = 123 bytes
 		// not-static bytes = pool_addr_script_len + cb_input_sz + (space_for_en_in_coinbase?0:10)
 		//     --- it costs 10 extra bytes to do the OP_RETURN based extranonce
-		
+
 		if (!space_for_en_in_coinbase) {
 			cb_req_sz[1] = cb_req_sz[2] = cb_req_sz[3] = cb_req_sz[4] = cb_req_sz[5] = 119 + s->pool_addr_script_len + cb_input_sz + 10;
 		} else {
 			cb_req_sz[1] = cb_req_sz[2] = cb_req_sz[3] = cb_req_sz[4] = cb_req_sz[5] = 119 + s->pool_addr_script_len + cb_input_sz;
 			cb_req_sz[2] += 10; // always OP_RETURN extranonce for type 2
 		}
-		
+
 		// TYPE 1 - "Nicehash" friendly, max 500 bytes
 		i = datum_stratum_coinbase_fit_to_template(500, cb_req_sz[1], s);
 		generate_coinbase_txns_for_stratum_job_subtypebysize(s, 1, i, space_for_en_in_coinbase, cb1idx, cb2idx, false);
-		
+
 		// TYPE 3 - "Whatsminer" friendly, max 6500 bytes
 		i = datum_stratum_coinbase_fit_to_template(6500, cb_req_sz[3], s);
 		generate_coinbase_txns_for_stratum_job_subtypebysize(s, 3, i, space_for_en_in_coinbase, cb1idx, cb2idx, false);
-		
+
 		// TYPE 4 - "YUGE", max 16KB
 		i = datum_stratum_coinbase_fit_to_template(16000, cb_req_sz[4], s);
 		generate_coinbase_txns_for_stratum_job_subtypebysize(s, 4, i, space_for_en_in_coinbase, cb1idx, cb2idx, false);
-		
+
 		// TYPE 5 - "Antminer 2", max 2250 bytes
 		i = datum_stratum_coinbase_fit_to_template(2250, cb_req_sz[5], s);
 		generate_coinbase_txns_for_stratum_job_subtypebysize(s, 5, i, space_for_en_in_coinbase, cb1idx, cb2idx, false);
-		
+
 		// TYPE 2 - Older Antminer stock (S19)
 		i = datum_stratum_coinbase_fit_to_template(755, cb_req_sz[2], s);
 		generate_coinbase_txns_for_stratum_job_subtypebysize(s, 2, i, false, cb1idx, cb2idx, true);
 	}
-	
+
 	// prep binary versions of the coinbase for speeding up later
 	for(k=0;k<MAX_COINBASE_TYPES;k++) {
 		i = strlen(s->coinbase[k].coinb1);
@@ -741,7 +742,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 			s->coinbase[k].coinb2_len++;
 		}
 	}
-	
+
 	if (empty_only) {
 		i = strlen(s->subsidy_only_coinbase.coinb1);
 		s->subsidy_only_coinbase.coinb1_len = 0;
@@ -766,24 +767,24 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 	int slen = 0;
 	int cbvalid = 0;
 	int datum_id;
-	
+
 	if (!coinbaser) {
 		DLOG_WARN("Coinbaser is NULL Using default/empty");
 		s->available_coinbase_outputs_count = 0;
 		return 0;
 	}
-	
+
 	if (cblen < 9) {
 		// 0 outputs possible
 		DLOG_WARN("Coinbaser lentgh is invalid (too short). Using default/empty");
 		s->available_coinbase_outputs_count = 0;
 		return 0;
 	}
-	
+
 	DLOG_DEBUG("Coinbaser v2 size %d", cblen);
-	
+
 	datum_id = coinbaser[cidx]; cidx++;
-	
+
 	while (cidx < cblen) {
 		outval = upk_u64le(coinbaser, cidx); cidx+=8;
 		if ((outval + tally) > s->coinbase_value) {
@@ -796,7 +797,7 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 			// invalid script len?!?
 			break;
 		}
-		
+
 		tally += outval;
 		memcpy(s->available_coinbase_outputs[cbvalid].output_script, &coinbaser[cidx], slen); cidx+=slen;
 		// 64-bit value in sats is part of the output
@@ -806,14 +807,14 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 		} else {
 			s->available_coinbase_outputs[cbvalid].sigops = 0;
 		}
-		
+
 		s->available_coinbase_outputs[cbvalid].output_script_len = slen;
-		
+
 		cbvalid++;
-		
+
 		if (cbvalid >= 512) break; // limitation of datum for now
 	}
-	
+
 	s->datum_coinbaser_id = datum_id;
 	s->available_coinbase_outputs_count = cbvalid;
 	if (coinbaser && must_free) free(coinbaser);
@@ -825,9 +826,9 @@ void *datum_coinbaser_thread(void *ptr) {
 	T_DATUM_STRATUM_JOB *s = NULL;
 	bool need_coinbaser = false;
 	int i;
-	
+
 	DLOG_DEBUG("Coinbaser thread active");
-	
+
 	while(1) {
 		// check if we need to fetch any new coinbasers
 		// check if the stratum job has been updated
@@ -844,7 +845,7 @@ void *datum_coinbaser_thread(void *ptr) {
 			}
 		}
 		pthread_rwlock_unlock(&stratum_global_job_ptr_lock);
-		
+
 		if (need_coinbaser) {
 			// fetch remote coinbaser for job
 			DLOG_DEBUG("Job %d needs a coinbaser!", sjob);
@@ -866,7 +867,7 @@ void *datum_coinbaser_thread(void *ptr) {
 				DLOG_DEBUG("Generated and notified.");
 			}
 		}
-		
+
 		usleep(12000);
 	}
 }


### PR DESCRIPTION
This adds optional `DLOG_DEBUG` statements in `src/datum_coinbaser.c` to print:
- Raw coinb1 and coinb2 hex (proof of built txn data)
- Configured payout address
- Payout value (sats + BTC)
- Primary/secondary coinbase tags

Particularly useful when `mining_pool_address = ""` (i.e. NOT mining in the pool, "lottery" mining, keeping the reward, etc).

Under such circumstances, these extra debugs provide some extra confidence that the coinbasetxn has been built as expected, and (in the extremely unlikely scenario you hit a block) will send through to the correct address.

You cannot simple use `bitcoin-cli getblocktemplate ...` to address these concerns, as it doesn't have the additional context that DATUM is using here to stitch together the txn it's actually using.

If I did everything correctly, the logs should only appear at log level 0 (ALL) or 1 (DEBUG) - no impact at INFO or higher.

I've tested using a single BitAxe miner with `mining_pool_address = ""` and saw the expected output logged via `journalctl -u datum_gateway -f`.

If you don't think these would be useful, feel free to close - or, if there's a better way to implement debug logs like these, let me know!