### PR TITLE
feat: set names to threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.13)
 
 project(DATUM VERSION 0.4.1 LANGUAGES C)
 
+add_compile_definitions(_GNU_SOURCE)
+
 # Enable C23 if supported, else fall back to C11 for compatibility
 if(CMAKE_VERSION VERSION_LESS "3.21")
     # Older CMake: C23 not recognized; use C11
@@ -97,6 +99,11 @@ if(HAVE_EPOLL_WAIT)
 	set(EPOLL_SHIM_LIBRARIES "")
 else()
 	pkg_check_modules(EPOLL_SHIM REQUIRED epoll-shim)
+endif()
+
+check_function_exists(pthread_setname_np HAVE_PTHREAD_SETNAME_NP)
+if(HAVE_PTHREAD_SETNAME_NP)
+	add_compile_definitions(HAVE_PTHREAD_SETNAME_NP)
 endif()
 
 cmake_pop_check_state()

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -1381,6 +1381,7 @@ size_t datum_api_fill_config_errors(const char *var_start, const size_t var_name
 }
 
 void *datum_restart_thread(void *ptr) {
+	pthread_setname_np(pthread_self(), "restart");
 	// Give logger some time
 	usleep(500000);
 	
@@ -1837,6 +1838,7 @@ static struct MHD_Daemon *datum_api_try_start(unsigned int flags, const int sock
 }
 
 void *datum_api_thread(void *ptr) {
+	pthread_setname_np(pthread_self(), "api");
 	struct MHD_Daemon *daemon;
 	
 	if (!datum_config.api_listen_port) {

--- a/src/datum_blocktemplates.c
+++ b/src/datum_blocktemplates.c
@@ -348,6 +348,7 @@ T_DATUM_TEMPLATE_DATA *datum_gbt_parser(json_t *gbt) {
 }
 
 void *datum_gateway_fallback_notifier(void *args) {
+	pthread_setname_np(pthread_self(), "fallback");
 	CURL *tcurl = NULL;
 	char req[512];
 	char p1[72];
@@ -393,6 +394,7 @@ void *datum_gateway_fallback_notifier(void *args) {
 }
 
 void *datum_gateway_template_thread(void *args) {
+	pthread_setname_np(pthread_self(), "template");
 	CURL *tcurl = NULL;
 	json_t *gbt = NULL, *res_val;
 	uint64_t i = 0;

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -821,6 +821,7 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 }
 
 void *datum_coinbaser_thread(void *ptr) {
+	pthread_setname_np(pthread_self(), "coinbaser");
 	int sjob = -1;
 	T_DATUM_STRATUM_JOB *s = NULL;
 	bool need_coinbaser = false;

--- a/src/datum_logger.c
+++ b/src/datum_logger.c
@@ -250,6 +250,7 @@ time_t get_midnight_timestamp(void) {
 }
 
 void * datum_logger_thread(void *ptr) {
+	pthread_setname_np(pthread_self(), "logger");
 	int buffer_id,offline_buffer_id;
 	int i,j;
 	uint64_t sts,ets,lflush;

--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -1463,6 +1463,7 @@ bool datum_protocol_is_active(void) {
 }
 
 void *datum_protocol_client(void *args) {
+	pthread_setname_np(pthread_self(), "protocol");
 	struct addrinfo hints, *res, *p;
 	int sockfd = -1;
 	int epollfd, nfds;

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -97,6 +97,9 @@ int get_remote_ip(int fd, char *ip, size_t max_len) {
 
 void *datum_threadpool_thread(void *arg) {
 	T_DATUM_THREAD_DATA *my = (T_DATUM_THREAD_DATA *)arg;
+	char thread_name[16];
+	snprintf(thread_name, sizeof(thread_name), "worker-%x", (unsigned int)my->thread_id);
+	pthread_setname_np(pthread_self(), thread_name);
 	int i, nfds, n, cidx, j;
 	size_t leftover = 0;
 	
@@ -668,6 +671,7 @@ bool datum_sockets_setup_listening_sockets(const char * const purpose, const cha
 }
 
 void *datum_gateway_listener_thread(void *arg) {
+	pthread_setname_np(pthread_self(), "listener");
 	int i, ret;
 	bool rejecting_now = false;
 	uint64_t last_reject_msg_tsms = 0, curtime_tsms = 0;

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -127,6 +127,7 @@ void datum_stratum_v1_shutdown_all(void) {
 
 // Started as its own pthread during startup
 void *datum_stratum_v1_socket_server(void *arg) {
+	pthread_setname_np(pthread_self(), "stratum");
 	// setup the stratum v1 DATUM socket server
 	T_DATUM_SOCKET_APP *app;
 	pthread_t pthread_datum_stratum_socket_server;

--- a/src/datum_submitblock.c
+++ b/src/datum_submitblock.c
@@ -89,6 +89,7 @@ void datum_submitblock_doit(CURL *tcurl, char *url, const char *submitblock_req,
 }
 
 void *datum_submitblock_thread(void *ptr) {
+	pthread_setname_np(pthread_self(), "submitblock");
 	CURL *tcurl = NULL;
 	int i;
 	

--- a/src/datum_utils.h
+++ b/src/datum_utils.h
@@ -39,7 +39,12 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <pthread.h>
 #include "datum_logger.h"
+
+#ifndef HAVE_PTHREAD_SETNAME_NP
+#define pthread_setname_np(thread, name) ((void)0)
+#endif
 
 void datum_utils_init(void);
 


### PR DESCRIPTION
Fixes #148 

```
BEFORE:
ps -T -p 2987412 -o pid,tid,comm,args
    PID     TID COMMAND         COMMAND
2987412 2987412 datum_gateway   ./datum_gateway
2987412 2987413 datum_gateway   ./datum_gateway
2987412 2987414 datum_gateway   ./datum_gateway
2987412 2987415 datum_gateway   ./datum_gateway
2987412 2987416 datum_gateway   ./datum_gateway
2987412 2987417 datum_gateway   ./datum_gateway
2987412 2987418 MHD-single      ./datum_gateway
2987412 2987419 datum_gateway   ./datum_gateway
2987412 2987420 datum_gateway   ./datum_gateway
2987412 2987421 datum_gateway   ./datum_gateway

AFTER:
ps -T -p 2993005 -o pid,tid,comm,args
    PID     TID COMMAND         COMMAND
2993005 2993005 datum_gateway   ./datum_gateway
2993005 2993006 logger          ./datum_gateway
2993005 2993007 api             ./datum_gateway
2993005 2993008 coinbaser       ./datum_gateway
2993005 2993009 template        ./datum_gateway
2993005 2993010 stratum         ./datum_gateway
2993005 2993011 MHD-single      ./datum_gateway
2993005 2993012 fallback        ./datum_gateway
2993005 2993013 submitblock     ./datum_gateway
2993005 2993014 listener        ./datum_gateway

```
