### PR TITLE
api: Set MHD connection idle timeout to 120s

### DIFF
--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -1175,6 +1175,7 @@ void *datum_api_thread(void *ptr) {
 	
 	daemon = MHD_start_daemon(MHD_USE_AUTO | MHD_USE_INTERNAL_POLLING_THREAD, datum_config.api_listen_port, NULL, NULL, &datum_api_answer, NULL,
 	                          MHD_OPTION_CONNECTION_LIMIT, 128,
+	                          MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int)120,
 	                          MHD_OPTION_NOTIFY_COMPLETED, datum_api_request_completed, NULL,
 	                          MHD_OPTION_LISTENING_ADDRESS_REUSE, (unsigned int)1,
 	                          MHD_OPTION_END);


### PR DESCRIPTION
## Summary

Add `MHD_OPTION_CONNECTION_TIMEOUT` (120s) to the libmicrohttpd daemon
started by `datum_api_thread`. Without it, idle keep-alive connections
are never reaped, and with `MHD_OPTION_CONNECTION_LIMIT` fixed at 128
the API/UI gradually silts up with zombie clients until no new
connections are accepted. Stratum is on a separate accept loop so it
keeps working; the user-visible symptom is "UI frozen, stratum fine,
restart fixes it for a few days."

## Evidence from a production gateway

Collected on a live gateway while the UI was unreachable, with stratum
healthy (~230 clients, ~40 PH/s):

```
--- UI :7152 connection count by state ---
  SYN_SENT: 3
  LISTEN: 1
  CLOSE_WAIT: 3
  ESTABLISHED: 142      <-- at/over the CONNECTION_LIMIT of 128

--- STRATUM :23334 connection count by state ---
  SYN_RECV: 1
  LISTEN: 1
  ESTABLISHED: 238      <-- healthy

--- thread states ---
7   S (sleeping)  do_epoll_wait  MHD-single   <-- alive, not deadlocked
...

--- curl http://127.0.0.1:7152/ (5s timeout) ---
curl: (28) Connection timed out after 5001 milliseconds
```

`CLOSE_WAIT` is low (3), so these aren't half-closed clients — they're
legitimate keep-alives that the server is holding open forever. Only
`fd`s open: 375 sockets out of a 65536 rlimit, so the issue isn't fd
exhaustion. The MHD polling thread is alive in `epoll_wait`; it just
won't accept new connections because its managed-connection count is
at the cap.

A restart of the gateway clears the state and the UI is reachable again
for several days until the pool re-saturates.

## The fix

One-line addition to `datum_api_thread`:

```c
MHD_OPTION_CONNECTION_TIMEOUT, (unsigned int)120,
```

120s is long enough that active dashboard clients (which refresh on
shorter intervals) are never culled, and short enough that dead
keep-alives are reaped in a couple of minutes so the 128-slot pool
cannot accumulate zombies over days of uptime.