### PR TITLE
Avoid "doxxing" if admin_password is set or not

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ set(WEB_RESOURCES
 	www/coinbaser_top.html
 	www/config.html
 	www/config_errors.html
+	www/config_noauth_top.html
 	www/config_restart.html
 	www/threads_top.html
 	www/foot.html

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -713,7 +713,8 @@ int datum_api_coinbaser(struct MHD_Connection *connection) {
 	return datum_api_submit_uncached_response(connection, MHD_HTTP_OK, response);
 }
 
-int datum_api_thread_dashboard(struct MHD_Connection *connection) {
+static
+struct MHD_Response *datum_api_thread_dashboard_inner(const bool have_admin) {
 	struct MHD_Response *response;
 	int sz=0, max_sz = 0, j, ii;
 	char *output = NULL;
@@ -727,10 +728,8 @@ int datum_api_thread_dashboard(struct MHD_Connection *connection) {
 	max_sz = www_threads_top_html_sz + www_foot_html_sz + (global_stratum_app->max_threads * 512) + 2048; // approximate max size of each row
 	output = calloc(max_sz+16,1);
 	if (!output) {
-		return MHD_NO;
+		return datum_api_create_empty_mhd_response();
 	}
-	
-	const bool have_admin = datum_config.api_admin_password_len;
 	
 	tsms = current_time_millis();
 	
@@ -778,6 +777,20 @@ int datum_api_thread_dashboard(struct MHD_Connection *connection) {
 	
 	response = MHD_create_response_from_buffer (sz, (void *) output, MHD_RESPMEM_MUST_FREE);
 	MHD_add_response_header(response, "Content-Type", "text/html");
+	return response;
+}
+
+static
+struct MHD_Response *datum_api_thread_dashboard_inner_noadmin() {
+	return datum_api_thread_dashboard_inner(/*have_admin*/ false);
+}
+
+static
+int datum_api_thread_dashboard(struct MHD_Connection *connection) {
+	if (!datum_api_check_admin_password_httponly(connection, datum_api_thread_dashboard_inner_noadmin)) {
+		return MHD_YES;
+	}
+	struct MHD_Response * const response = datum_api_thread_dashboard_inner(/*have_admin*/ true);
 	return datum_api_submit_uncached_response(connection, MHD_HTTP_OK, response);
 }
 

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -533,6 +533,10 @@ size_t datum_api_fill_authfail_error(const char * const var_start, const size_t 
 	return www_auth_failed_html_sz;
 }
 
+static struct MHD_Response *datum_api_create_response_authfail_config_view() {
+	return datum_api_create_response_authfail(www_config_noauth_top_html, www_config_noauth_top_html_sz);
+}
+
 static struct MHD_Response *datum_api_create_response_authfail_config() {
 	const size_t max_sz = www_config_errors_html_sz + www_auth_failed_html_sz;
 	
@@ -1087,6 +1091,10 @@ int datum_api_config_dashboard(struct MHD_Connection *connection) {
 	struct MHD_Response *response;
 	size_t sz = 0, max_sz = 0;
 	char *output = NULL;
+	
+	if (!datum_api_check_admin_password_httponly(connection, datum_api_create_response_authfail_config_view)) {
+		return MHD_YES;
+	}
 	
 	max_sz = www_config_html_sz * 2;
 	output = malloc(max_sz);

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -822,14 +822,6 @@ int datum_api_client_dashboard(struct MHD_Connection *connection) {
 	
 	sz = snprintf(output, max_sz-1-sz, "%s", www_clients_top_html);
 	
-	if (!datum_config.api_admin_password_len) {
-		sz += snprintf(&output[sz], max_sz-1-sz, "This page requires admin access (add \"admin_password\" to \"api\" section of config file)");
-		sz += snprintf(&output[sz], max_sz-1-sz, "%s", www_foot_html);
-		
-		response = MHD_create_response_from_buffer(sz, output, MHD_RESPMEM_MUST_FREE);
-		MHD_add_response_header(response, "Content-Type", "text/html");
-		return datum_api_submit_uncached_response(connection, MHD_HTTP_OK, response);
-	}
 	if (!datum_api_check_admin_password_httponly(connection, datum_api_create_response_authfail_clients)) {
 		return MHD_YES;
 	}

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -448,7 +448,7 @@ bool datum_api_check_admin_password_httponly(struct MHD_Connection * const conne
 		}
 		const enum MHD_DigestAuthAlgorithm algo = datum_api_pick_digest_algo(connection, nonce_is_stale);
 		struct MHD_Response * const response = auth_failure_response_creator();
-		ret = MHD_queue_auth_fail_response2(connection, realm, datum_config.api_csrf_token, response, nonce_is_stale ? MHD_YES : MHD_NO, algo);
+		ret = MHD_queue_auth_fail_response2(connection, realm, "x", response, nonce_is_stale ? MHD_YES : MHD_NO, algo);
 		MHD_destroy_response(response);
 		return false;
 	}

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -734,7 +734,10 @@ struct MHD_Response *datum_api_thread_dashboard_inner(const bool have_admin) {
 	tsms = current_time_millis();
 	
 	sz = snprintf(output, max_sz-1-sz, "%s", www_threads_top_html);
-	sz += snprintf(&output[sz], max_sz-1-sz, "<form action='/cmd' method='post'><input type='hidden' name='csrf' value='%s' /><TABLE><TR><TD><U>TID</U></TD>  <TD><U>Connection Count</U></TD>  <TD><U>Sub Count</U></TD> <TD><U>Approx. Hashrate</U></TD> <TD><U>Command</U></TD></TR>", datum_config.api_csrf_token);
+	if (have_admin) {
+		sz += snprintf(&output[sz], max_sz-1-sz, "<form action='/cmd' method='post'><input type='hidden' name='csrf' value='%s' />", datum_config.api_csrf_token);
+	}
+	sz += snprintf(&output[sz], max_sz-1-sz, "<TABLE><TR><TD><U>TID</U></TD>  <TD><U>Connection Count</U></TD>  <TD><U>Sub Count</U></TD> <TD><U>Approx. Hashrate</U></TD> <TD><U>Command</U></TD></TR>");
 	for(j=0;j<global_stratum_app->max_threads;j++) {
 		thr = 0.0;
 		subs = 0;
@@ -767,9 +770,9 @@ struct MHD_Response *datum_api_thread_dashboard_inner(const bool have_admin) {
 			sz += snprintf(&output[sz], max_sz-1-sz, ">Disconnect All</button></TD></TR>");
 		}
 	}
-	sz += snprintf(&output[sz], max_sz-1-sz, "</TABLE></form>");
+	sz += snprintf(&output[sz], max_sz-1-sz, "</TABLE>");
 	if (have_admin) {
-		sz += snprintf(&output[sz], max_sz-1-sz, "<script>");
+		sz += snprintf(&output[sz], max_sz-1-sz, "</form><script>");
 		sz += snprintf(&output[sz], max_sz-1-sz, www_assets_post_js, datum_config.api_csrf_token);
 		sz += snprintf(&output[sz], max_sz-1-sz, "</script>");
 	}

--- a/www/config_noauth_top.html
+++ b/www/config_noauth_top.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>DATUM Gateway Configuration</title>
+	<link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
+	<link rel="stylesheet" type="text/css" href="./assets/style.css">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+	<div class="container">
+		<div class="header">
+			<h1><img src="/assets/icons/datum_logo.svg" alt="(DATUM Logo)" style="vertical-align: text-top" width="28" height="33"> DATUM <span>GATEWAY</span></h1>
+		</div>
+		<div class="menu-container">
+			<a href="/">Status</a>
+			<a href="/config" style="background-color: darkslategrey;">Config</a>
+			<a href="/clients">Clients</a>
+			<a href="/threads">Threads</a>
+			<a href="/coinbaser">Coinbaser</a>
+		</div>
+	</div>
+	
+	<div class="tables-container">
+		<div class="table-wrapper">
+			<div class="table-container">
+				<h2>Configuration</h2>


### PR DESCRIPTION
This makes /config (viewing) admin-only, and checks authentication for /threads even before commands are clicked

It also removes the helpful "you need to set admin_pass" message from /clients
