### PR TITLE
Bugfix: Add length checks for server-provided data

### DIFF
--- a/src/datum_blocktemplates.c
+++ b/src/datum_blocktemplates.c
@@ -137,7 +137,7 @@ T_DATUM_TEMPLATE_DATA *datum_gbt_parser(json_t *gbt) {
 	T_DATUM_TEMPLATE_DATA *tdata;
 	const char *s;
 	int i,j;
-	json_t *tx_array;
+	json_t *tx_array, *jval;
 	
 	tdata = get_next_template_ptr();
 	if (!tdata) {
@@ -193,37 +193,37 @@ T_DATUM_TEMPLATE_DATA *datum_gbt_parser(json_t *gbt) {
 		return NULL;
 	}
 	
-	s = json_string_value(json_object_get(gbt, "bits"));
-	if (!s) {
-		DLOG_ERROR("Missing data from GBT JSON (bits)");
-		return NULL;
-	}
-	if (strlen(s) != 8) {
+	jval = json_object_get(gbt, "bits");
+	if (json_string_length(jval) != 8) {
 		DLOG_ERROR("Wrong bits length from GBT JSON");
 		return NULL;
 	}
+	s = json_string_value(jval);
 	strcpy(tdata->bits, s);
 	
-	s = json_string_value(json_object_get(gbt, "previousblockhash"));
-	if (!s) {
+	jval = json_object_get(gbt, "previousblockhash");
+	if (json_string_length(jval) != 64) {
 		DLOG_ERROR("Missing data from GBT JSON (previousblockhash)");
 		return NULL;
 	}
-	strncpy(tdata->previousblockhash, s, 71);
+	s = json_string_value(jval);
+	strcpy(tdata->previousblockhash, s);
 	
-	s = json_string_value(json_object_get(gbt, "target"));
-	if (!s) {
+	jval = json_object_get(gbt, "target");
+	if (json_string_length(jval) != 64) {
 		DLOG_ERROR("Missing data from GBT JSON (target)");
 		return NULL;
 	}
-	strncpy(tdata->block_target_hex, s, 71);
+	s = json_string_value(jval);
+	strcpy(tdata->block_target_hex, s);
 	
-	s = json_string_value(json_object_get(gbt, "default_witness_commitment"));
-	if (!s) {
+	jval = json_object_get(gbt, "default_witness_commitment");
+	if (json_string_length(jval) < 38 || json_string_length(jval) > 95) {
 		DLOG_ERROR("Missing data from GBT JSON (default_witness_commitment)");
 		return NULL;
 	}
-	strncpy(tdata->default_witness_commitment, s, 95);
+	s = json_string_value(jval);
+	strcpy(tdata->default_witness_commitment, s);
 	
 	// "20000000", "192e17d5", "66256be5"
 	// version, bits, time
@@ -271,20 +271,22 @@ T_DATUM_TEMPLATE_DATA *datum_gbt_parser(json_t *gbt) {
 			tdata->txns[i].index_raw = i+1;
 			
 			// txid
-			s = json_string_value(json_object_get(tx, "txid"));
-			if (!s) {
+			jval = json_object_get(tx, "txid");
+			if (json_string_length(jval) != 64) {
 				DLOG_ERROR("Missing data from GBT JSON transactions[%d] (txid)",i);
 				return NULL;
 			}
+			s = json_string_value(jval);
 			strcpy(tdata->txns[i].txid_hex, s);
 			hex_to_bin_le(tdata->txns[i].txid_hex, tdata->txns[i].txid_bin);
 			
 			// hash
-			s = json_string_value(json_object_get(tx, "hash"));
-			if (!s) {
+			jval = json_object_get(tx, "hash");
+			if (json_string_length(jval) != 64) {
 				DLOG_ERROR("Missing data from GBT JSON transactions[%d] (hash)",i);
 				return NULL;
 			}
+			s = json_string_value(jval);
 			strcpy(tdata->txns[i].hash_hex, s);
 			hex_to_bin_le(tdata->txns[i].hash_hex, tdata->txns[i].hash_bin);
 			

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -785,6 +785,11 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 	datum_id = coinbaser[cidx]; cidx++;
 	
 	while (cidx < cblen) {
+		if (cidx + 8 + 1 > cblen) {
+			DLOG_ERROR("Coinbaser length is invalid (mid-parsing). Using default/empty");
+			s->available_coinbase_outputs_count = 0;
+			return 0;
+		}
 		outval = upk_u64le(coinbaser, cidx); cidx+=8;
 		if ((outval + tally) > s->coinbase_value) {
 			// we can't include this value, since it would put us over our total available!
@@ -792,9 +797,10 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 			break;
 		}
 		slen = coinbaser[cidx]; cidx++;
-		if ((slen < 2) || (slen > 64)) {
-			// invalid script len?!?
-			break;
+		if (slen < 2 || slen > 64 || cidx + slen > cblen) {
+			DLOG_ERROR("Script length (%d) is invalid. Using default/empty", slen);
+			s->available_coinbase_outputs_count = 0;
+			return 0;
 		}
 		
 		tally += outval;

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -775,7 +775,7 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 	
 	if (cblen < 9) {
 		// 0 outputs possible
-		DLOG_WARN("Coinbaser lentgh is invalid (too short). Using default/empty");
+		DLOG_WARN("Coinbaser length is invalid (too short). Using default/empty");
 		s->available_coinbase_outputs_count = 0;
 		return 0;
 	}


### PR DESCRIPTION
Rather than mine an invalid generation tx, check lengths and fallback more gracefully.

(Also checks txid/hash lengths on GBT responses.)