### PR TITLE
sockets: Make datum_socket_setoptions less fatal at runtime

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -1518,10 +1518,7 @@ void *datum_protocol_client(void *args) {
 		
 		// TCP_NODELAY!  Probably not needed since we group sends, but can't hurt.
 		if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int)) < 0) {
-			DLOG_FATAL("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
-			close(sockfd);
-			sockfd = -1;
-			continue;
+			DLOG_WARN("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
 		}
 		
 		// Start the connection process.

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -584,7 +584,9 @@ void *datum_gateway_listener_thread(void *arg) {
 		return NULL;
 	}
 	
-	datum_socket_setoptions(listen_sock);
+	if (!datum_socket_setoptions(listen_sock)) {
+		return "datum_socket_setoptions failed";
+	}
 	memset(&serveraddr, 0, sizeof(serveraddr));
 	serveraddr.sin_family = AF_INET;
 	serveraddr.sin_port = htons(app->listen_port);
@@ -660,7 +662,11 @@ void *datum_gateway_listener_thread(void *arg) {
 				}
 				
 				DLOG_DEBUG("Accepted socket to fd %d", conn_sock);
-				datum_socket_setoptions(conn_sock);
+				if (!datum_socket_setoptions(conn_sock)) {
+					DLOG_ERROR("datum_socket_setoptions failed for incoming connection on fd %d", conn_sock);
+					close(conn_sock);
+					continue;
+				}
 				
 				// assign socket to a thread
 				i = assign_to_thread(app, conn_sock);
@@ -676,25 +682,27 @@ void *datum_gateway_listener_thread(void *arg) {
 	return NULL;
 }
 
-void datum_socket_setoptions(int sock) {
+bool datum_socket_setoptions(int sock) {
 	int opts;
 	int flag = 1;
 	
 	opts = fcntl(sock,F_GETFL);
 	if (opts < 0) {
-		DLOG_FATAL("fcntl(F_GETFL) failed: %s", strerror(errno));
-		panic_from_thread(__LINE__);
+		DLOG_ERROR("fcntl(F_GETFL) failed: %s", strerror(errno));
+		return false;
 	}
 	opts = (opts | O_NONBLOCK);
 	if (fcntl(sock,F_SETFL,opts) < 0) {
-		DLOG_FATAL("fcntl(F_SETFL) failed: %s", strerror(errno));
-		panic_from_thread(__LINE__);
+		DLOG_ERROR("fcntl(F_SETFL) failed: %s", strerror(errno));
+		return false;
 	}
 	
 	// Set the TCP_NODELAY option
 	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
 		DLOG_WARN("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
 	}
+	
+	return true;
 }
 
 int datum_socket_send_string_to_client(T_DATUM_CLIENT_DATA *c, char *s) {

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -684,21 +684,21 @@ void *datum_gateway_listener_thread(void *arg) {
 
 bool datum_socket_setoptions(int sock) {
 	int opts;
-	int flag = 1;
+	static const int flag = 1;
 	
 	opts = fcntl(sock,F_GETFL);
 	if (opts < 0) {
 		DLOG_ERROR("fcntl(F_GETFL) failed: %s", strerror(errno));
 		return false;
 	}
-	opts = (opts | O_NONBLOCK);
-	if (fcntl(sock,F_SETFL,opts) < 0) {
+	opts |= O_NONBLOCK;
+	if (fcntl(sock, F_SETFL, opts) < 0) {
 		DLOG_ERROR("fcntl(F_SETFL) failed: %s", strerror(errno));
 		return false;
 	}
 	
 	// Set the TCP_NODELAY option
-	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
+	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (void *)&flag, sizeof(flag)) < 0) {
 		DLOG_WARN("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
 	}
 	

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -585,7 +585,10 @@ void *datum_gateway_listener_thread(void *arg) {
 	}
 	
 	if (!datum_socket_setoptions(listen_sock)) {
-		return "datum_socket_setoptions failed";
+		close(listen_sock);
+		DLOG_FATAL("datum_socket_setoptions failed");
+		panic_from_thread(__LINE__);
+		return NULL;
 	}
 	memset(&serveraddr, 0, sizeof(serveraddr));
 	serveraddr.sin_family = AF_INET;

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -687,21 +687,21 @@ void *datum_gateway_listener_thread(void *arg) {
 
 bool datum_socket_setoptions(int sock) {
 	int opts;
-	int flag = 1;
+	static const int flag = 1;
 	
 	opts = fcntl(sock,F_GETFL);
 	if (opts < 0) {
 		DLOG_ERROR("fcntl(F_GETFL) failed: %s", strerror(errno));
 		return false;
 	}
-	opts = (opts | O_NONBLOCK);
-	if (fcntl(sock,F_SETFL,opts) < 0) {
+	opts |= O_NONBLOCK;
+	if (fcntl(sock, F_SETFL, opts) < 0) {
 		DLOG_ERROR("fcntl(F_SETFL) failed: %s", strerror(errno));
 		return false;
 	}
 	
 	// Set the TCP_NODELAY option
-	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
+	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (void *)&flag, sizeof(flag)) < 0) {
 		DLOG_WARN("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
 	}
 	

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -584,7 +584,12 @@ void *datum_gateway_listener_thread(void *arg) {
 		return NULL;
 	}
 	
-	datum_socket_setoptions(listen_sock);
+	if (!datum_socket_setoptions(listen_sock)) {
+		close(listen_sock);
+		DLOG_FATAL("datum_socket_setoptions failed");
+		panic_from_thread(__LINE__);
+		return NULL;
+	}
 	memset(&serveraddr, 0, sizeof(serveraddr));
 	serveraddr.sin_family = AF_INET;
 	serveraddr.sin_port = htons(app->listen_port);
@@ -660,7 +665,11 @@ void *datum_gateway_listener_thread(void *arg) {
 				}
 				
 				DLOG_DEBUG("Accepted socket to fd %d", conn_sock);
-				datum_socket_setoptions(conn_sock);
+				if (!datum_socket_setoptions(conn_sock)) {
+					DLOG_ERROR("datum_socket_setoptions failed for incoming connection on fd %d", conn_sock);
+					close(conn_sock);
+					continue;
+				}
 				
 				// assign socket to a thread
 				i = assign_to_thread(app, conn_sock);
@@ -676,25 +685,27 @@ void *datum_gateway_listener_thread(void *arg) {
 	return NULL;
 }
 
-void datum_socket_setoptions(int sock) {
+bool datum_socket_setoptions(int sock) {
 	int opts;
 	int flag = 1;
 	
 	opts = fcntl(sock,F_GETFL);
 	if (opts < 0) {
-		DLOG_FATAL("fcntl(F_GETFL) failed: %s", strerror(errno));
-		panic_from_thread(__LINE__);
+		DLOG_ERROR("fcntl(F_GETFL) failed: %s", strerror(errno));
+		return false;
 	}
 	opts = (opts | O_NONBLOCK);
 	if (fcntl(sock,F_SETFL,opts) < 0) {
-		DLOG_FATAL("fcntl(F_SETFL) failed: %s", strerror(errno));
-		panic_from_thread(__LINE__);
+		DLOG_ERROR("fcntl(F_SETFL) failed: %s", strerror(errno));
+		return false;
 	}
 	
 	// Set the TCP_NODELAY option
 	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
 		DLOG_WARN("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
 	}
+	
+	return true;
 }
 
 int datum_socket_send_string_to_client(T_DATUM_CLIENT_DATA *c, char *s) {

--- a/src/datum_sockets.c
+++ b/src/datum_sockets.c
@@ -693,8 +693,7 @@ void datum_socket_setoptions(int sock) {
 	
 	// Set the TCP_NODELAY option
 	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, sizeof(int)) < 0) {
-		DLOG_FATAL("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
-		panic_from_thread(__LINE__);
+		DLOG_WARN("setsockopt(TCP_NODELAY) failed: %s", strerror(errno));
 	}
 }
 

--- a/src/datum_sockets.h
+++ b/src/datum_sockets.h
@@ -162,7 +162,7 @@ typedef struct T_DATUM_THREAD_DATA {
 } T_DATUM_THREAD_DATA;
 
 void *datum_gateway_listener_thread(void *arg);
-void datum_socket_setoptions(int sock);
+[[nodiscard]] bool datum_socket_setoptions(int sock);
 
 int datum_socket_send_string_to_client(T_DATUM_CLIENT_DATA *c, char *s);
 int datum_socket_send_chars_to_client(T_DATUM_CLIENT_DATA *c, char *s, int len);


### PR DESCRIPTION
(Also makes TCP_NODELAY non-mandatory in _protocol_)