### PR TITLE
coinbaser: Drop buggy and unused must_free paramater from datum_coinbaser_v2_parse

### DIFF
--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -758,7 +758,7 @@ void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_o
 	}
 }
 
-int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, int cblen, bool must_free) {
+int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, int cblen) {
 	// parse raw outputs from DATUM connection into a useful coinbaser
 	uint64_t outval = 0;
 	uint64_t tally = 0;
@@ -816,7 +816,6 @@ int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, i
 	
 	s->datum_coinbaser_id = datum_id;
 	s->available_coinbase_outputs_count = cbvalid;
-	if (coinbaser && must_free) free(coinbaser);
 	return cbvalid;
 }
 

--- a/src/datum_coinbaser.h
+++ b/src/datum_coinbaser.h
@@ -40,6 +40,6 @@ int datum_coinbaser_init(void);
 void generate_coinbase_txns_for_stratum_job_subtypebysize(T_DATUM_STRATUM_JOB *s, int coinbase_index, int remaining_size, bool space_for_en_in_coinbase, int *cb1idx, int *cb2idx, bool special_coinb1);
 void generate_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool empty_only);
 void generate_base_coinbase_txns_for_stratum_job(T_DATUM_STRATUM_JOB *s, bool new_block);
-int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, int cblen, bool must_free);
+int datum_coinbaser_v2_parse(T_DATUM_STRATUM_JOB *s, unsigned char *coinbaser, int cblen);
 
 #endif

--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -374,7 +374,7 @@ int datum_protocol_coinbaser_fetch(void *sptr) {
 	
 	// process received coinbase
 	if ((datum_coinbaser_v2_response) && (datum_coinbaser_v2_response_value[datum_coinbaser_v2_response_buf_idx] == value)) {
-		i = datum_coinbaser_v2_parse(s, datum_coinbaser_v2_response, datum_coinbaser_v2_response_len[datum_coinbaser_v2_response_buf_idx], false);
+		i = datum_coinbaser_v2_parse(s, datum_coinbaser_v2_response, datum_coinbaser_v2_response_len[datum_coinbaser_v2_response_buf_idx]);
 	}
 	
 	pthread_mutex_unlock(&datum_protocol_coinbaser_fetch_mutex);


### PR DESCRIPTION
Early exits would have leaked