### PR TITLE
Coinbase buffers of a published stratum job can be rewritten concurrently with mining.notify / share validation

### DIFF
--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -851,6 +851,24 @@ void *datum_coinbaser_thread(void *ptr) {
 		if (need_coinbaser) {
 			// fetch remote coinbaser for job
 			DLOG_DEBUG("Job %d needs a coinbaser!", sjob);
+			// if the job already went out to miners -- this thread can pick a job up
+			// several seconds late when the previous job's fetch pinned it past the
+			// publish deadline -- any coinbaser fetched now could only be discarded
+			// below, so skip the round trip and leave the job exactly as published.
+			// the flag never reverts for a given job, so a publish landing mid-fetch
+			// is still caught by the locked check after the fetch.
+			locks_ready = need_coinbaser_rwlocks_init_done;
+			if (locks_ready) {
+				pthread_rwlock_rdlock(&need_coinbaser_rwlocks[sjob]);
+				if (s->coinbase_published) {
+					pthread_rwlock_unlock(&need_coinbaser_rwlocks[sjob]);
+					DLOG_INFO("Job %s was published before its coinbaser fetch started; skipping fetch", s->job_id);
+					need_coinbaser = false;
+					usleep(12000);
+					continue;
+				}
+				pthread_rwlock_unlock(&need_coinbaser_rwlocks[sjob]);
+			}
 			// datum_protocol_coinbaser_fetch() commits the response into the job as it
 			// parses it, before we get to decide whether we can still use it, so keep
 			// what we would have to put back if it turns out to be too late.
@@ -864,8 +882,10 @@ void *datum_coinbaser_thread(void *ptr) {
 			}
 			// hold the job's coinbaser lock across the check and the rewrite, so a
 			// stratum thread cannot decide to publish this job while the coinbase
-			// buffers it would read are half rewritten.  sample the init flag once:
-			// it is set by the stratum server thread, which is started after this one.
+			// buffers it would read are half rewritten.  re-sample the init flag
+			// after the fetch (it can only go false->true, and this sample alone
+			// governs the lock/unlock pair below): it is set by the stratum server
+			// thread, which is started after this one.
 			locks_ready = need_coinbaser_rwlocks_init_done;
 			if (locks_ready) {
 				pthread_rwlock_wrlock(&need_coinbaser_rwlocks[sjob]);

--- a/src/datum_coinbaser.c
+++ b/src/datum_coinbaser.c
@@ -824,6 +824,9 @@ void *datum_coinbaser_thread(void *ptr) {
 	int sjob = -1;
 	T_DATUM_STRATUM_JOB *s = NULL;
 	bool need_coinbaser = false;
+	bool locks_ready = false;
+	unsigned char saved_coinbaser_id = 0;
+	int saved_coinbaser_outputs = 0;
 	int i;
 	
 	DLOG_DEBUG("Coinbaser thread active");
@@ -848,22 +851,52 @@ void *datum_coinbaser_thread(void *ptr) {
 		if (need_coinbaser) {
 			// fetch remote coinbaser for job
 			DLOG_DEBUG("Job %d needs a coinbaser!", sjob);
+			// datum_protocol_coinbaser_fetch() commits the response into the job as it
+			// parses it, before we get to decide whether we can still use it, so keep
+			// what we would have to put back if it turns out to be too late.
+			saved_coinbaser_id = s->datum_coinbaser_id;
+			saved_coinbaser_outputs = s->available_coinbase_outputs_count;
 			if (datum_protocol_is_active()) {
 				i = datum_protocol_coinbaser_fetch(s);
 			} else {
 				s->available_coinbase_outputs_count = 0;
 				i = 0;
 			}
+			// hold the job's coinbaser lock across the check and the rewrite, so a
+			// stratum thread cannot decide to publish this job while the coinbase
+			// buffers it would read are half rewritten.  sample the init flag once:
+			// it is set by the stratum server thread, which is started after this one.
+			locks_ready = need_coinbaser_rwlocks_init_done;
+			if (locks_ready) {
+				pthread_rwlock_wrlock(&need_coinbaser_rwlocks[sjob]);
+			}
+			if ((i>=0) && (s->coinbase_published)) {
+				// this job was already broadcast with the coinbase it had.  its coinb1 and
+				// coinb2 are being copied out by send_mining_notify() and rebuilt by share
+				// validation without a lock, so rewriting them now would invalidate work
+				// that is already in flight with miners.  drop the late coinbaser and put
+				// the job back the way it was published -- the coinbaser ID travels with the
+				// job's POW submissions, so it has to keep describing the coinbase the job
+				// actually pays.  need_coinbaser stays set on the job: the full coinbase
+				// types were never built for it, so it has to keep going out with the base
+				// coinbase it was published with.
+				DLOG_INFO("Coinbaser for job %s arrived after its work was published; discarding", s->job_id);
+				s->datum_coinbaser_id = saved_coinbaser_id;
+				s->available_coinbase_outputs_count = saved_coinbaser_outputs;
+				need_coinbaser = false;
+				i = -1;
+			}
 			if (i>=0) {
 				DLOG_DEBUG("Generating coinbases for up to %d outputs", i);
 				generate_coinbase_txns_for_stratum_job(s, false);
-				if (need_coinbaser_rwlocks_init_done) {
-					pthread_rwlock_wrlock(&need_coinbaser_rwlocks[sjob]);
+				if (locks_ready) {
 					s->need_coinbaser = false;
-					pthread_rwlock_unlock(&need_coinbaser_rwlocks[sjob]);
 					need_coinbaser = false;
 				}
 				DLOG_DEBUG("Generated and notified.");
+			}
+			if (locks_ready) {
+				pthread_rwlock_unlock(&need_coinbaser_rwlocks[sjob]);
 			}
 		}
 		

--- a/src/datum_stratum.c
+++ b/src/datum_stratum.c
@@ -401,6 +401,12 @@ bool stratum_job_coinbaser_ready(T_DATUM_STRATUM_THREADPOOL_DATA *sdata, T_DATUM
 	// backup timeout for coinbaser on these jobs
 	if ((sdata->loop_tsms > job->tsms) && (sdata->loop_tsms - job->tsms) > 5000) {
 		// enforce a timeout of 5 seconds on waiting on a coinbaser...
+		// this job is going out to miners with the coinbase it has right now, so
+		// latch it under the job's coinbaser lock.  a coinbaser that turns up after
+		// this point must not rewrite the buffers we are about to broadcast.
+		pthread_rwlock_wrlock(&need_coinbaser_rwlocks[job->global_index]);
+		job->coinbase_published = true;
+		pthread_rwlock_unlock(&need_coinbaser_rwlocks[job->global_index]);
 		sdata->full_coinbase_ready = false;
 		return true;
 	}
@@ -2076,6 +2082,7 @@ void update_stratum_job(T_DATUM_TEMPLATE_DATA *block_template, bool new_block, i
 	} else {
 		s->need_coinbaser = false;
 	}
+	s->coinbase_published = false; // already covered by the memset above; explicit for documentation
 	
 	// if this is a new block, invalidate all old work
 	if (new_block) {

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -171,6 +171,10 @@ typedef struct {
 	
 	bool need_coinbaser;
 	
+	// set once this job has been broadcast to miners with whatever coinbase it
+	// had at the time.  guarded by need_coinbaser_rwlocks[global_index].
+	bool coinbase_published;
+
 	bool is_datum_job;
 	unsigned char datum_job_idx;
 	unsigned char datum_coinbaser_id;

--- a/src/datum_stratum.h
+++ b/src/datum_stratum.h
@@ -172,7 +172,9 @@ typedef struct {
 	bool need_coinbaser;
 	
 	// set once this job has been broadcast to miners with whatever coinbase it
-	// had at the time.  guarded by need_coinbaser_rwlocks[global_index].
+	// had at the time.  guarded by need_coinbaser_rwlocks[global_index] once the
+	// job is globally visible (update_stratum_job clears it, without the lock,
+	// before the job is published to the jobs array).
 	bool coinbase_published;
 
 	bool is_datum_job;


### PR DESCRIPTION
`datum_coinbaser_thread()` rewrites the coinbase buffers of a stratum job that
the stratum threads have already broadcast to miners. When the coinbaser
response arrives it calls `generate_coinbase_txns_for_stratum_job(s, false)`
(`datum_coinbaser.c:859`) holding no lock — the `need_coinbaser_rwlocks[]` write
lock is taken afterwards, and only to guard the boolean flag
(`datum_coinbaser.c:860-865`). Meanwhile `send_mining_notify()` copies
`cb->coinb1` using `cb->coinb1_len` (`datum_stratum.c:1592`), stamps the miner's
PoT difficulty byte at `j->target_pot_index` (`datum_stratum.c:1598`) and sends
`cb->coinb2` as a NUL-terminated string (`datum_stratum.c:1617`), and
`client_mining_submit()` rebuilds the coinbase from the same buffers to validate
shares (`datum_stratum.c:1128-1130`, `datum_stratum.c:1149-1151`) — all without
a lock.

A miner notified while the rewrite is in flight therefore holds work the gateway
will not reproduce. Because the submit path rebuilds from whatever the buffers
contain *now*, every share that connection sends for that job fails
`upk_u32le(share_hash, 28) != 0` (`datum_stratum.c:1208`) and comes back
`[23,"H-not-zero"]` until its next notify. The job ID does not commit to the
coinbase contents and the submit path compares only its first 8 bytes
(`datum_stratum.c:1031`), so this never surfaces as stale or unknown work — it
looks like the miner is submitting bad shares.

### What lines the broadcast up with the rewrite

A job in `JOB_STATE_FULL_PRIORITY_WAIT_COINBASER` /
`JOB_STATE_FULL_NORMAL_WAIT_COINBASER` is held back until
`stratum_job_coinbaser_ready()` returns true, and that function gives up after
five seconds — `loop_tsms - job->tsms > 5000` (`datum_stratum.c:402-406`) —
publishing the job with `full_coinbase_ready` false. The coinbaser's own wait is
also five seconds (`datum_protocol.c:356-364`) and is armed a few milliseconds
after `job->tsms`, and on timeout it returns 0, which passes the `i >= 0` gate
and regenerates anyway. So an unanswered coinbaser fetch does not merely
*sometimes* collide with the broadcast: both timers expire within milliseconds
of each other, by construction, on the same job.

Three windows inside the rewrite are visible to a reader:

* `s->target_pot_index` is stored un-offset at `datum_coinbaser.c:550` and only
  corrected inside the per-type loop at `datum_coinbaser.c:582`. A notify sent in
  between stamps the miner's difficulty byte at the wrong offset, while share
  validation stamps it at the corrected one.
* `coinb1_len` / `coinb2_len` are zeroed and re-counted one byte at a time
  (`datum_coinbaser.c:730-743`). A notify sent in between copies
  `cb->coinb1_len << 1` characters out of a buffer whose length currently reads 0
  or partial, i.e. it hands the miner a truncated or empty coinb1.
* the coinb1/coinb2 hex strings themselves are rewritten in place with moving NUL
  terminators, and `cb->coinb2` is sent with a `strlen()`-based helper.

Note exactly which state is at risk, because it is narrower than it first looks.
On the timeout path `full_coinbase_ready` is false, so `cbselect` is 0
(`datum_stratum.c:1556-1573`) and miners are served coinbase type 0. Coinbase
types 1-5 are only ever selected once `full_coinbase_ready` is true, which
requires the regen to have already completed, so those buffers are *not* being
read concurrently — the concurrently-read state is `coinbase[0]`,
`subsidy_only_coinbase`, `target_pot_index` and `is_datum_job`. And the regen
rebuilds type 0 byte-identically, so the published *content* does not change
either. What corrupts the work is purely that the rebuild of that state is not
atomic with respect to its readers.

## Reproduction

Test host: Amazon Linux 2023, aarch64, kernel `6.1.176-221.360.amzn2023.aarch64`
(your CI covers aarch64, so this should be directly comparable). gcc 11.5.0
20240719 (Red Hat 11.5.0-5), cmake 3.22.2. Bitcoin Core v28.0.0 on `-regtest`
with 101 blocks mined so the coinbase is mature. datum_gateway built from
`a3da9e6975984fd0ae584f37d76fe4afe2c75bac`.

Gateway config: non-pooled (`datum.pool_host` empty, `pooled_mining_only` false),
one stratum thread, 120 client slots, `bitcoind.work_update_seconds` 30,
`stratum.vardiff_min` 1024, `share_stale_seconds` default 120. No DATUM Prime
connection is needed: with `datum_protocol_is_active()` false the coinbaser
thread still reaches the same regen call, because the else branch sets `i = 0`
(`datum_coinbaser.c:854-855`), which is exactly what the real
`datum_protocol_coinbaser_fetch()` returns when its own 5 s wait times out.

Two attachments: `repro-harness.patch` is debug-only scaffolding and
`fix.patch` is the proposed change. Every harness knob is env-gated; with all of
them unset the build is behaviourally identical to stock.

| env var | effect |
| --- | --- |
| `DATUM_DEBUG_COINBASER_DELAY_MS` | stand in for coinbaser fetch latency, so the response lands around or after the publish deadline |
| `DATUM_DEBUG_FAKE_COINBASER_OUTPUTS` | stand in for the payout set a real coinbaser response carries, so the regen writes materially different bytes instead of an identical rebuild |
| `DATUM_DEBUG_TEAR_LEN_US` | hold `coinbase[0].coinb1_len` at 0 during the re-count |
| `DATUM_DEBUG_TEAR_POT_US` | hold `s->target_pot_index` un-offset |
| `DATUM_DEBUG_LOG_REGEN` | log what the regen changed in the live buffers (lengths + hex excerpts) |
| `DATUM_DEBUG_SHARE_ZERO_BITS` | lower the hard-coded difficulty-1 share gate so a scripted CPU client can find genuine solutions |

The two `TEAR_*` knobs hold a state the writer really passes through; they make
a window that is otherwise microseconds wide wide enough to hit reliably from a
120-connection test. They do not create any state the stock code cannot reach —
the ThreadSanitizer results below were produced with the writer knobs *unset*.

The last knob is only there because the share gate is a fixed
`upk_u32le(share_hash, 28) != 0`, i.e. ~2^32 hashes per share, which a scripted
client cannot produce. It changes the PoW threshold and nothing else; the
rejection under test comes from the gateway rebuilding a *different* coinbase,
which fails any threshold. With the knob unset the limit collapses to 1 and the
comparison is exactly the original.

`race_client.py` (stdlib only) opens N independent TCP connections,
subscribes/authorizes, mines real double-SHA256 solutions against the work each
connection was actually sent, submits continuously, and logs per connection every
`mining.notify` with the full coinb1/coinb2 as received plus every submit result.
Every connection is served the same job, so if two connections received different
coinbase bytes under one job ID, the job was rewritten underneath them. Shares
mined against a job ID that has since been superseded are dropped rather than
submitted, so `stale-work` does not pollute the counts.

```
DATUM_DEBUG_SHARE_ZERO_BITS=12 DATUM_DEBUG_COINBASER_DELAY_MS=5100 \
DATUM_DEBUG_FAKE_COINBASER_OUTPUTS=64 DATUM_DEBUG_TEAR_LEN_US=1000000 \
DATUM_DEBUG_LOG_REGEN=1 ./datum_gateway -c datum.conf
python3 race_client.py --conns 120 --duration 600 --out run.jsonl --zero-bits 12
```

An affected run splits the connections into bands: the handful paced into the
rewrite window reject 100% of their shares for that job, the rest are clean. A
clean run has every connection at zero rejects and exactly one coinbase variant
per job ID.

## Results

Same host, same config and the same knobs on both sides of every comparison. One
submit per connection per 1.5 s; shares whose job ID had been superseded are
dropped by the client rather than submitted, so `stale-work` is not in the way.

**Stock (`repro-harness.patch` only) — 600 s, 120 connections, 21 jobs**

| | |
| --- | --- |
| accepted shares | 30,596 |
| `[23,"H-not-zero"]` | **1,071** |
| `stale-work` | 46 |
| unknown-work / any other reason | 0 |
| connections with at least one `H-not-zero` | 7 / 120 |
| connections with zero rejects | 110 / 120 |
| jobs where two different coinbases went out under one job ID | 20 / 21 |
| connection-jobs rejected 100 % of the time | 83 |

The connections split into bands. Per job the four connections the notify pacer
reached during the rewrite rejected every share for that job and recovered on the
next one; everything else was clean:

```
job_id=6a6ffffb03c0dc00  clients_notified=116  distinct_coinbase_variants=2
  variant 0: cb1len= 64  conns=112   accepts=1473  rejects=0
  variant 1: cb1len=  0  conns=  4   accepts=0     rejects=54  {'H-not-zero': 54}
      coinb1: LENGTH DIFFERS  rejected=0 bytes  accepted=64 bytes
      coinb2: IDENTICAL (90 bytes)
```

`cb1len=0` is the `coinb1_len = 0` window at `datum_coinbaser.c:732` observed by
`memcpy(cb1, cb->coinb1, cb->coinb1_len<<1)` at `datum_stratum.c:1592`. The
`stale-work` rejects are a rig artifact — the gateway paces a work change from
client index 0 upward, and with 120 clients on one stratum thread the last few
indices are occasionally not re-notified within
`share_stale_seconds + work_update_seconds`. They are reported separately
throughout and never counted as `H-not-zero`.

**Control, natural window only** (same binary and delay, `TEAR_LEN_US` unset,
300 s, 120 connections): 15,912 accepted shares, 11 late rewrites of published
jobs, **0** `H-not-zero`. Without the hold the window is too narrow to be hit by
a client this size; ThreadSanitizer still reports it (below).

**Fixed (`fix.patch`) — same knobs, same client**

| run | duration | accepts | `H-not-zero` | `stale-work` | discards logged |
| --- | --- | --- | --- | --- | --- |
| C1 | 600 s | 31,575 | **0** | 130 | 19 |
| C2 | 300 s | 16,017 | **0** | 147 | 10 |

The silence is attributable rather than vacuous: C1 logged 19
`"Coinbaser for job N arrived after its work was published; discarding"` lines
across the 20 jobs the client saw and C2 logged 10 across 11, so the collision
was armed on every job and intercepted every time. The one remaining job in each
run is the one whose coinbaser landed before any stratum thread reached the
publish decision — the timely path, which the patch leaves alone. No job
delivered more than one coinbase variant.

**Boundary sweep** — the same run with `DATUM_DEBUG_COINBASER_DELAY_MS` swept
across the 5,000 ms deadline, 240 s and 60 connections per point. `v1` is the
simpler "coinbaser compares its own clock to the deadline" variant; `v2` is
`fix.patch`.

| delay (ms) | v1 `H-not-zero` | v1 discards | v2 `H-not-zero` | v2 discards | v2 regens that ran |
| --- | --- | --- | --- | --- | --- |
| 4900 | **285** | 0 | **0** | 0 | 9 |
| 4950 | **371** | 0 | **0** | 0 | 9 |
| 4990 | **335** | 1 | **0** | 0 | 9 |
| 5010 | 0 | 9 | **0** | 8 | 1 |
| 5050 | 0 | 9 | **0** | 8 | 1 |

Under v1 the guard simply does not fire below the deadline while the rewrite
still runs into the broadcast. Under v2 the rewrite runs (9 regens at 4900 ms,
i.e. the race was armed) and the broadcast waits for it, so nothing is torn. With
the hold reduced 1 s → 100 ms and 120 connections for 420 s, v1 still produced
**176** `H-not-zero` and v2 produced **0**.

**Re-verified after the fix changed.** Review of the first pass found that the
discard left `datum_coinbaser_id` describing a coinbaser the job no longer paid;
the fix now restores it and `available_coinbase_outputs_count` on that path. The
fixed-binary runs were repeated on the new binary with the stock control repeated
alongside, same knobs, same client: stock **1,033** `H-not-zero` in 30,369
accepted shares, fixed **0** in 31,243 accepted shares with 19
discards, and the boundary sweep is 0 at all five delays (4,900 / 4,950 / 4,990 /
5,010 / 5,050 ms).

**At the shipped default `max_threads 8`** (`datum_conf.c:90`; everything above
uses 1, which is the weakest configuration for this patch because it removes the
convoy): 0 `H-not-zero` in 31,056 accepted shares with the coinbaser late and
discarded (19 discards), and 0 in 15,509 accepted shares at the 4,950 ms boundary
where the rewrite really runs while eight threads are trying to publish (11
rewrites, 0 discards) — the multi-threaded form of the case that produced 371
`H-not-zero` under the deadline-compare variant.


**Sanitizers**

* ThreadSanitizer, stock, delay only, no writer-side hold: 7 reports pairing
  `generate_coinbase_txns_for_stratum_job` (writes to `coinb1_len`,
  `coinb2_len`, `target_pot_index`, `is_datum_job`, the coinb1/coinb2 bins) with
  `send_mining_notify` and `client_mining_submit`. With the hold enabled, 9.
* ThreadSanitizer, `fix.patch`, same knobs and also at the 4,950 ms boundary:
  **0** reports of that pair. What remains in both stock and fixed runs is the
  pre-existing `datum_logger.c` races and the pre-existing statistics races
  (`datum_stratum_v1_global_subscriber_count`,
  `datum_stratum_v1_est_total_th_sec`, socket accounting), unrelated to this
  change. The pre-existing `datum_logger.c` lock-order-inversion report appears
  identically (2 occurrences) with and without the patch, so the new lock does
  not add an inversion.
* AddressSanitizer + UndefinedBehaviorSanitizer, `fix.patch`, 300 s live run:
  **0** errors, **0** UBSan `runtime error:` lines, over 3,900 accepted shares
  and 10 discards.

**Remaining pre-publication window** (see "Known remaining window" below).
A churn probe — 20 steady connections plus 5 that reconnect every 3 s, delay
4,500 ms so the entire rewrite sits *before* publication — gives 518
`H-not-zero` on stock and 0 on the fixed build. On stock, 512 of those are the
notify-side band and 6 are isolated single-share rejections on connections whose
notify was intact, which is what a torn read on the *submit* side looks like. The
fixed build's 0 does not by itself prove the pre-publication window is closed:
with one stratum thread, the thread that waits on the job's lock is also the
thread that serves subscribes and submits, so nothing reads during the rewrite.
I would not claim more than the published-job case from these numbers.


## Fix

`fix.patch` makes the decision to publish a job and the decision to rewrite its
coinbase mutually exclusive, using the per-job lock that already exists.

* `T_DATUM_STRATUM_JOB` gains `coinbase_published`, guarded by
  `need_coinbaser_rwlocks[global_index]` and cleared when the job slot is reused.
* `stratum_job_coinbaser_ready()` sets it under that lock on the timeout path,
  immediately before returning true — i.e. before any `send_mining_notify()` for
  that job can run.
* `datum_coinbaser_thread()` takes the same write lock across the check *and* the
  regen. If the job was already published, the coinbaser is discarded with a log
  line and the job finishes out with the coinbase it was broadcast with;
  otherwise the regen completes before any stratum thread can get through the
  readiness check and start notifying.
* the discard also puts back `datum_coinbaser_id` and
  `available_coinbase_outputs_count`. `datum_protocol_coinbaser_fetch()` commits
  the response into the job as it parses it (`datum_coinbaser.c:817-818`) before
  the caller can decide whether it is still usable, and the ID is sent to the
  server with the job's POW submissions (`datum_protocol.c:1371`). Without the
  restore, a discarded job would advertise the discarded coinbaser's ID while
  paying the base coinbase. Stock cannot reach that state because the regen
  always follows the parse; this patch has to keep it that way.

`stratum_job_coinbaser_ready()` takes the lock with no
`need_coinbaser_rwlocks_init_done` guard, matching what stock already does a few
lines further down (`datum_stratum.c:408`) — deliberate, not an oversight: that
function only runs on stratum threads, which are started after the locks are
initialised. The coinbaser thread does check the flag, because it is started
before them (`datum_gateway.c:203` vs `:230`), and it now samples it into a local
so the lock and unlock cannot disagree.

The reader hot path is untouched: `send_mining_notify()` and
`client_mining_submit()` take no new locks. The new write-lock acquisition in
`stratum_job_coinbaser_ready()` happens on the branch that then sets
`sdata->new_job = false`, so it is taken about once per job per stratum thread,
not per notify.

There is one second-order cost worth stating plainly rather than leaving for a
reviewer to find. `datum_stratum_v1_socket_thread_loop()` holds
`stratum_global_job_ptr_lock` for read from `datum_stratum.c:431` to `:461` and
calls `stratum_job_coinbaser_ready()` at `:437` inside that span. With this
patch that call can block on the per-job write lock, so a stratum thread can now
hold the global job-pointer read lock for the duration of a regen, and
`update_stratum_job()`'s write acquisition at `:2118` queues behind it. Measured
on the test host at `max_threads 8`, the coinbaser holds the job lock for 56-63 µs
with a 64-output payout set and 157-168 µs with the 512-output maximum, and the
waits stratum threads actually observed were 27-89 µs, at most once per job. It
is bounded by one coinbase rebuild and scales with that rebuild on a slower core
— but it is not free, and a maintainer may prefer to hoist that readiness check
out of the global lock as a follow-up.

A job whose coinbaser missed the deadline keeps its base coinbase for that work
cycle instead of picking up the late payout set. **This forfeits nothing.**
`stratum_job_coinbaser_ready()` tests the five-second timeout at
`datum_stratum.c:402`, before it ever reads `need_coinbaser` at `:408`, and on
that path returns true with `full_coinbase_ready` false unconditionally. So once
a job is past five seconds every stratum thread serves `coinbase[0]` for it
whether or not the coinbaser landed: a coinbaser arriving after publication was
already unusable in stock. The patch does not throw away a payout set that would
otherwise have been paid — it stops that unusable response from corrupting work
in flight.

I first tried the smaller change — have the coinbaser thread compare
`current_time_millis() - s->tsms` against the same 5000 ms deadline and discard
if it has passed — and it is not sufficient. The two threads read two different
clocks with no mutual exclusion, so a coinbaser that reads 4,999 ms still enters
the rewrite while a stratum thread that samples `loop_tsms` at 5,001 ms publishes
into it. That variant is the `v1` column of the boundary sweep above: it still
produces `H-not-zero` bands, with zero discards logged, whenever the coinbaser
lands just inside the deadline. The lock is what closes it.

Two smaller/alternative changes are worth addressing before anyone proposes them.

**Tightening `i>=0` to `i>0` at `datum_coinbaser.c:857`.** One character, no new
state, and it does help: on the timeout path the fetch returns 0, the regen is an
`empty_only` rebuild that reproduces `coinbase[0]` byte for byte, and running it
is pure work for zero benefit while a notify may be reading those buffers. That
is exactly the scenario this report leads with, so the one-character change would
suppress the most common instance. It does not fix the bug. A coinbaser that
genuinely lands late returns `i > 0`, sails through that test, and rewrites the
published job — the `P1_*`/`P2_*` sweeps below are that case, and they are the
reason the patch exists.

**Double-buffering instead of discarding.** Give the job two banks of
`coinbase[MAX_COINBASE_TYPES]` plus an index the writer flips once the new bank
is complete. Readers do one relaxed load of that index and then walk a bank that
is guaranteed not to be mutated, so no reader lock is needed and the late payout
set survives instead of being dropped. It costs another ~300 KB per job slot at
the current buffer sizes, or a reshape of `T_DATUM_STRATUM_JOB`, and it needs the
`target_pot_index`/`is_datum_job` reads folded into the same bank to be complete.
That is a real change to a hot structure, so I did not put it in a bug-fix patch,
but it is the natural follow-up and I am happy to prepare it if you would rather
keep the coinbaser.

### Known remaining window

This closes the case where the job has been *published* — the one that hurts,
because every miner the pacer reaches during the rewrite is affected. It does not
make the buffers wholesale safe, and I would rather say so than imply it does.

Three reader routes reach a job's coinbase without passing through
`stratum_job_coinbaser_ready()`, so they can still touch a job whose coinbaser is
being applied *before* that job is published:

* `client_mining_subscribe()` answers a subscribe with an immediate
  `send_mining_notify()` (`datum_stratum.c:1778`);
* the vardiff path sends a quickdiff notify from
  `stratum_update_vardiff()` (`datum_stratum.c:827`), off share submission, which
  reads `cb->coinb1`/`coinb1_len`/`coinb2` at `:1592`/`:1617` with no lock;
* `client_mining_submit()` itself, for a miner that connected during the up-to-5 s
  window before publication and started submitting straight away.

That window is the length of one `generate_coinbase_txns_for_stratum_job()` call,
against the whole notify-pacing window that this patch closes. It is real and I
measured it: at `max_threads 8`, with 5 connections reconnecting every 3 s and the
rewrite stretched to a second, stock handed 5 of those connections a notify with
an empty coinb1 and rejected 15 of their shares. On the patched build the same
probe produced 0 torn notifies and 0 rejects over 100 reconnects — but that is
narrowing by scheduling, not closing by construction: every stratum thread runs
`stratum_job_coinbaser_ready()` in the job-handling phase of its loop before it
services client commands, so while the coinbaser holds the write lock the socket
threads park on that job's read lock and none of them reaches a subscribe. A
thread already inside a client-command batch when the rewrite starts is still
free to read.

Closing it properly means taking the job's read lock around the coinbase reads in
`send_mining_notify()` and `client_mining_submit()`, i.e. touching the per-share
path — or the double-buffer above, which needs no reader lock at all. I did not
want to fold either into this change without a maintainer's view on the cost.
