### PR TITLE
api: Let an operator replace the dashboard stylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Run the datum_gateway executable with the -? flag for detailed configuration inf
 There is an [example configuration file included in the doc/ directory](doc/example_datum_gateway_config.json) you may wish to use as a template.
 Note that the API/web admin password is also used for preventing CSRF attacks, so it is crucial you set it to something reasonably secure (or disable the API/web interface entirely).
 
+The dashboard's stylesheet can be replaced without rebuilding: set `api`.`custom_css_file` to the path of a CSS file and it is served in place of the built-in `/assets/style.css`. The file is read once at startup, so a change to it means a gateway restart; if it cannot be read, the gateway logs an error and serves the built-in stylesheet. An example is in [doc/skins/](doc/skins/); the page markup it has to cover is in `www/`, and the per-page `<style>` blocks there still apply on top of it, so a replacement needs slightly more specific selectors to override those.
+
 You should review the [documentation on usernames](doc/usernames.md) next.
 Once you have everything running, you can point miners at the Gateway.
 

--- a/doc/skins/graphite.css
+++ b/doc/skins/graphite.css
@@ -1,0 +1,315 @@
+/*
+ * graphite: a replacement dashboard stylesheet for the DATUM Gateway.
+ *
+ * Use it with  "api": { "custom_css_file": "/path/to/graphite.css" }.
+ * It covers the same class names as www/assets/style.css. The pages in
+ * www/ also carry their own <style> blocks, which load after this file,
+ * so the rules here that compete with those use one extra level of
+ * specificity (body button, .setting-row label.label) rather than
+ * !important. The one !important is on the active menu link, whose
+ * background is set inline in the templates.
+ */
+
+:root {
+	--bg: #14161a;
+	--panel: #1d2026;
+	--panel-edge: #2a2e36;
+	--row: #181b20;
+	--label: #22262d;
+	--text: #d8dbe0;
+	--muted: #8d939c;
+	--accent: #7fb3ff;
+	--accent-strong: #a9cdff;
+	--warn: #e0a458;
+	--bad: #e06c6c;
+	--font: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	--mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+html {
+	background: var(--bg);
+}
+
+body {
+	background: var(--bg);
+	color: var(--text);
+	margin: 0;
+	font-family: var(--font);
+	font-size: 15px;
+	line-height: 1.45;
+}
+
+a {
+	color: var(--accent);
+	text-decoration: none;
+}
+
+a:hover {
+	color: var(--accent-strong);
+	text-decoration: underline;
+}
+
+/* Header and menu */
+
+.container {
+	max-width: 960px;
+	margin: 0 auto;
+	padding: 18px 16px 0;
+}
+
+.header {
+	background: transparent;
+	color: var(--text);
+	text-align: center;
+	padding: 0;
+	margin: 0;
+	border-radius: 0;
+}
+
+.header h1 {
+	margin: 0 0 12px;
+	font-size: 1.35rem;
+	font-weight: 600;
+	letter-spacing: 0.06em;
+}
+
+.header h1 span {
+	color: var(--muted);
+	font-weight: 400;
+}
+
+.header-content img,
+.header h1 img {
+	vertical-align: text-top;
+}
+
+.menu-container {
+	background: transparent;
+	padding: 0;
+	text-align: center;
+	border-radius: 0;
+	border-bottom: 1px solid var(--panel-edge);
+	padding-bottom: 12px;
+}
+
+.menu-container a {
+	display: inline-block;
+	background: var(--panel);
+	color: var(--muted);
+	padding: 7px 16px;
+	margin: 3px;
+	border: 1px solid var(--panel-edge);
+	border-radius: 999px;
+	font-weight: 500;
+	font-size: 0.95rem;
+	transition: none;
+}
+
+.menu-container a:hover {
+	background: var(--label);
+	color: var(--text);
+	text-decoration: none;
+}
+
+/* The templates mark the current page with an inline background color. */
+.menu-container a[style] {
+	background: var(--label) !important;
+	color: var(--accent-strong);
+	border-color: var(--accent);
+}
+
+/* Panels and tables */
+
+.content {
+	margin-bottom: 20px;
+}
+
+.tables-container {
+	width: 100%;
+	max-width: 1400px;
+	margin: 0 auto;
+	padding: 0 8px;
+	box-sizing: border-box;
+}
+
+.table-wrapper {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.table-container {
+	background: var(--panel);
+	border: 1px solid var(--panel-edge);
+	border-radius: 8px;
+	padding: 16px;
+	margin: 10px;
+	flex: 1 1 100%;
+	box-sizing: border-box;
+	overflow-x: auto;
+}
+
+.table-container h2 {
+	color: var(--text);
+	text-align: left;
+	font-size: 1rem;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	margin: 0 0 10px;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--panel-edge);
+}
+
+table {
+	width: 100%;
+	table-layout: auto;
+	border-collapse: collapse;
+}
+
+th {
+	text-align: left;
+	color: var(--muted);
+	font-weight: 600;
+	font-size: 0.85rem;
+	padding: 8px 10px;
+	border-bottom: 1px solid var(--panel-edge);
+}
+
+tr {
+	border-bottom: 1px solid var(--panel-edge);
+}
+
+tr:last-child {
+	border-bottom: none;
+}
+
+td {
+	padding: 8px 10px;
+	color: var(--text);
+	vertical-align: top;
+}
+
+td.label {
+	background: var(--label);
+	color: var(--muted);
+	width: 1%;
+	white-space: nowrap;
+}
+
+td:not(.label) {
+	background: var(--row);
+}
+
+.table-footer {
+	text-align: center;
+	margin-top: 24px;
+}
+
+@media (min-width: 1100px) {
+	.table-wrapper {
+		flex-wrap: nowrap;
+	}
+	
+	.table-container {
+		flex: 1 1 800px;
+		margin: 14px;
+	}
+	
+	.table-wrapper + .table-container {
+		flex: 1 1 800px;
+		margin: 14px auto;
+	}
+}
+
+.fixed-width {
+	font-family: var(--mono);
+	font-size: 0.9em;
+}
+
+.leading_zeros {
+	color: var(--muted);
+}
+
+.note {
+	text-align: center;
+	font-size: 0.85rem;
+	color: var(--muted);
+}
+
+.err {
+	color: var(--bad);
+}
+
+/* Config page: these outrank the block in www/config.html */
+
+body button {
+	background: var(--label);
+	color: var(--accent);
+	border: 1px solid var(--panel-edge);
+	border-radius: 6px;
+	padding: 8px 18px;
+	margin: 4px;
+	font: inherit;
+	font-weight: 600;
+	cursor: pointer;
+	transition: none;
+}
+
+body button:hover {
+	color: var(--accent-strong);
+	border-color: var(--accent);
+}
+
+body button[disabled] {
+	color: var(--muted);
+	background: var(--panel);
+	border-color: var(--panel-edge);
+	cursor: default;
+}
+
+.table-container .setting-row {
+	border-bottom: 1px solid var(--panel-edge);
+}
+
+.table-container .setting-row:last-child {
+	border-bottom: none;
+}
+
+.setting-row label.label {
+	padding: 10px;
+	background: var(--label);
+	color: var(--muted);
+	white-space: nowrap;
+}
+
+.setting-row label.tip {
+	display: block;
+	padding: 2px 10px 10px;
+	background: var(--label);
+	color: var(--muted);
+	font-size: 0.8rem;
+	font-style: normal;
+}
+
+body input,
+body select {
+	color: var(--text);
+	background: var(--row);
+	border: 1px solid var(--panel-edge);
+	border-radius: 4px;
+	padding: 6px 8px;
+	font: inherit;
+	z-index: 1;
+}
+
+body input:focus,
+body select:focus {
+	outline: none;
+	border-color: var(--accent);
+}
+
+body input[readonly],
+body input[disabled],
+body select[readonly] {
+	color: var(--muted);
+}

--- a/src/datum_api.c
+++ b/src/datum_api.c
@@ -36,6 +36,7 @@
 // This is quick and dirty for now.  Will be improved over time.
 
 #include <assert.h>
+#include <errno.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -555,6 +556,63 @@ static struct MHD_Response *datum_api_create_response_authfail_config() {
 
 static struct MHD_Response *datum_api_create_response_authfail_threads() {
 	return datum_api_create_response_authfail(www_threads_top_html, www_threads_top_html_sz);
+}
+
+// Operator-supplied replacement for /assets/style.css (api.custom_css_file), loaded once at startup
+static char *datum_api_custom_css = NULL;
+static size_t datum_api_custom_css_sz = 0;
+static char datum_api_custom_css_etag[67];
+
+#define DATUM_API_CUSTOM_CSS_MAX_SZ (1024*1024)
+
+static void datum_api_load_custom_css(void) {
+	const char * const path = datum_config.api_custom_css_file;
+	if (!path[0]) return;
+	
+	FILE * const f = fopen(path, "rb");
+	if (!f) {
+		DLOG_ERROR("Could not open api.custom_css_file %s: %s (using the built-in stylesheet)", path, strerror(errno));
+		return;
+	}
+	if (fseek(f, 0, SEEK_END)) {
+		DLOG_ERROR("Could not read api.custom_css_file %s: %s (using the built-in stylesheet)", path, strerror(errno));
+		fclose(f);
+		return;
+	}
+	const long len = ftell(f);
+	if (len < 0 || len > DATUM_API_CUSTOM_CSS_MAX_SZ) {
+		DLOG_ERROR("api.custom_css_file %s is %ld bytes; the limit is %d (using the built-in stylesheet)", path, len, DATUM_API_CUSTOM_CSS_MAX_SZ);
+		fclose(f);
+		return;
+	}
+	rewind(f);
+	char * const buf = malloc(len + 1);
+	if (!buf) {
+		DLOG_ERROR("Could not allocate %ld bytes for api.custom_css_file (using the built-in stylesheet)", len);
+		fclose(f);
+		return;
+	}
+	if (fread(buf, 1, len, f) != (size_t)len) {
+		DLOG_ERROR("Could not read api.custom_css_file %s (using the built-in stylesheet)", path);
+		free(buf);
+		fclose(f);
+		return;
+	}
+	fclose(f);
+	buf[len] = 0;
+	
+	unsigned char digest[32];
+	my_sha256(digest, buf, len);
+	datum_api_custom_css_etag[0] = '"';
+	for (int i = 0; i < 32; ++i) {
+		snprintf(&datum_api_custom_css_etag[1 + (i * 2)], 3, "%02x", digest[i]);
+	}
+	datum_api_custom_css_etag[65] = '"';
+	datum_api_custom_css_etag[66] = 0;
+	
+	datum_api_custom_css = buf;
+	datum_api_custom_css_sz = len;
+	DLOG_INFO("Dashboard stylesheet replaced by %s (%ld bytes)", path, len);
 }
 
 static int datum_api_asset(struct MHD_Connection * const connection, const char * const mimetype, const char * const data, const size_t datasz, const char * const etag) {
@@ -1772,6 +1830,9 @@ enum MHD_Result datum_api_answer(void *cls, struct MHD_Connection *connection, c
 			} else if (!strcmp(url, "/assets/icons/favicon.ico")) {
 				return datum_api_asset(connection, "image/x-icon", www_assets_icons_favicon_ico, www_assets_icons_favicon_ico_sz, www_assets_icons_favicon_ico_etag);
 			} else if (!strcmp(url, "/assets/style.css")) {
+				if (datum_api_custom_css) {
+					return datum_api_asset(connection, "text/css", datum_api_custom_css, datum_api_custom_css_sz, datum_api_custom_css_etag);
+				}
 				return datum_api_asset(connection, "text/css", www_assets_style_css, www_assets_style_css_sz, www_assets_style_css_etag);
 			}
 			break;
@@ -1867,6 +1928,9 @@ void *datum_api_thread(void *ptr) {
 	if (!datum_sockets_setup_listening_sockets("API", datum_config.api_listen_addr, datum_config.api_listen_port, listen_socks, &listen_socks_len)) {
 		return NULL;
 	}
+	
+	// Load before the daemon starts so no request can race the swap
+	datum_api_load_custom_css();
 	
 	daemon = datum_api_try_start(0, listen_socks[0]);
 	

--- a/src/datum_conf.c
+++ b/src/datum_conf.c
@@ -142,6 +142,8 @@ const T_DATUM_CONFIG_ITEM datum_config_options[] = {
 	{ .var_type = DATUM_CONF_BOOL, 		.category = "api",	 		.name = "modify_conf",				.description = "Enable modifying the config file from API/dashboard",
 		.example_default = true,
 		.required = false, .ptr = &datum_config.api_modify_conf, 						.default_bool = false },
+	{ .var_type = DATUM_CONF_STRING, 	.category = "api",	 		.name = "custom_css_file",			.description = "Path to a CSS file that replaces the built-in dashboard stylesheet (read once at startup; blank = built-in)",
+		.required = false, .ptr = datum_config.api_custom_css_file,					.default_string[0] = "", .max_string_len = sizeof(datum_config.api_custom_css_file) },
 	
 	// extra block submissions list
 	{ .var_type = DATUM_CONF_STRING_ARRAY, 	.category = "extra_block_submissions", 	.name = "urls",		.description = "Array of bitcoind RPC URLs to submit our blocks to directly.  Include auth info: http://user:pass@IP",

--- a/src/datum_conf.h
+++ b/src/datum_conf.h
@@ -137,6 +137,7 @@ typedef struct {
 	int api_listen_port;
 	bool api_allow_insecure_auth;
 	bool api_modify_conf;
+	char api_custom_css_file[1024];
 	json_t *config_json;
 	
 	int extra_block_submissions_count;


### PR DESCRIPTION
## What
Adds `api.custom_css_file`: a path to a CSS file that is served in place of the built-in `/assets/style.css`. Ships one replacement stylesheet, `doc/skins/graphite.css`, and a README paragraph.

## Why
The dashboard's look is compiled into the binary. Anyone who wants it different has to rebuild, and any restyle that lands has to suit everyone. With the stylesheet swappable at the URL every page already links, an operator picks a look per gateway, the default stays exactly as it is, and alternate skins can be shared as plain files without touching this repository's templates.

## How I tested
Built, `--test` passes. With the skin configured, `GET /assets/style.css` returns the file byte for byte, the `ETag` is its sha256, and a request with `If-None-Match` gets 304. With a bad path the startup log says so and the built-in stylesheet is served. Unset is unchanged. Rendered the status, clients, and threads pages with the skin against a gateway with no node attached.

## Risk and rollback
Off unless the key is set. The file is read once at startup, capped at 1 MiB, and a read failure falls back rather than failing startup. Revert the commit.

## Still unsure about
Whether the example skin belongs under `doc/skins/` or somewhere you would rather keep it. The per-page `<style>` blocks in `www/` still apply on top of any replacement, so a skin needs slightly more specific selectors to beat them; the header comment in the skin explains that. Deduplicating those blocks into the stylesheet would be a separate change.
