### PR TITLE
logger: Wait for the writer thread before returning from init

### DIFF
--- a/src/datum_logger.c
+++ b/src/datum_logger.c
@@ -465,5 +465,14 @@ int datum_logger_init(void) {
 	
 	pthread_create(&pthread_datum_logger_thread, NULL, datum_logger_thread, NULL);
 	
+	// Messages logged before the writer thread is up go to the console or
+	// nowhere, so give it a moment to open the log file before returning.
+	for (int i = 0; i < 2000 && !datum_logger_initialized; ++i) {
+		usleep(1000);
+	}
+	if (!datum_logger_initialized) {
+		DLOG_WARN("Logger thread not ready after 2 seconds; early startup messages may be lost");
+	}
+	
 	return 0;
 }


### PR DESCRIPTION
## What
`datum_logger_init` now waits, up to two seconds, for the writer thread to open the log file before returning.

## Why
It starts the thread and returns at once. Anything logged in the next millisecond, which includes `datum_protocol_init` and `datum_api_init`, goes to the console if console logging is on and nowhere if it is off. With `log_to_console: false` and a log file, the `DATUM pool host is blank. NON-POOLED MINING!` warning never reaches the file. Seen on a testnet4 gateway today: the file opens with the API thread's first line and the startup warnings are gone.

## How I tested
Same config both ways (console off, file on, INFO level), a gateway with no node attached, five seconds. Before: `NON-POOLED` appears 0 times in the file. After: once. Then on a testnet4 gateway with its real file-only config: the warning and the API thread's startup lines are in the file, where the previous build's run of the same config had only the template thread's lines. `--test` passes. The wait is bounded and the thread panics on its own if the file cannot be opened, so startup cannot hang on it.

## Risk and rollback
Startup is a few milliseconds slower. Revert the commit.
