### PR TITLE
protocol: Bound the 0x50 0x11 transaction reply to the buffer

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -123,7 +123,11 @@ uint64_t datum_protocol_mainloop_tsms = 0;
 uint64_t latest_server_msg_tsms = 0;
 
 // may be used by this thread when crafting replies to server commands
-unsigned char temp_data[DATUM_PROTOCOL_MAX_CMD_DATA_SIZE + 16384];
+// Scratch buffer for replies built on the protocol thread, and the most a
+// 0x50 0x11 reply may hold before its terminator and padding.
+#define DATUM_PROTOCOL_TEMP_DATA_SIZE (DATUM_PROTOCOL_MAX_CMD_DATA_SIZE + 16384)
+#define DATUM_STXLIST_REPLY_MAX (DATUM_PROTOCOL_MAX_CMD_DATA_SIZE - 113)
+unsigned char temp_data[DATUM_PROTOCOL_TEMP_DATA_SIZE];
 
 unsigned char datum_protocol_setup_new_job_idx(void *sx) {
 	// Called by the stratum job updater.  Must be thread safe.
@@ -609,9 +613,17 @@ int datum_protocol_job_validation_stxlist(unsigned char *data) {
 	return 1;
 }
 
-int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
+// The 0x50 0x11 reply is built in temp_data and sent as one command, so it
+// must stay under what datum_protocol_bulk_cmd accepts with room for the 0xFE
+// terminator and up to 111 bytes of padding appended after the loop.
+static bool datum_protocol_stxlist_reply_fits(size_t offset, size_t txn_size) {
+	return offset + 3 + txn_size <= DATUM_STXLIST_REPLY_MAX;
+}
+
+int datum_protocol_job_validation_stxlist_byid(int len, unsigned char *data) {
 	// the server is requesting missing transactions
 	// send them
+	if (len < 3) return 0;
 	unsigned char job_index = data[0];
 	uint16_t req_count = upk_u16le(data, 1);
 	
@@ -629,6 +641,23 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 		msg[i] = 0x91; i++;
 		msg[i] = 0xFF; i++;
 		msg[i] = 0xF3; i++;
+		
+		// pad with some randomness
+		j = 1 + (rand() % 100);
+		memset(&msg[i], rand(), j);
+		i+=j;
+		
+		datum_protocol_mining_cmd(msg, i);
+		return 1;
+	}
+	
+	if (3 + 2 * (int)req_count > len) {
+		// the index list is shorter than the count claims
+		// error response to 0x50 0x11
+		msg[i] = 0x50; i++;
+		msg[i] = 0x91; i++;
+		msg[i] = job_index; i++;
+		msg[i] = 0xF4; i++;
 		
 		// pad with some randomness
 		j = 1 + (rand() % 100);
@@ -710,6 +739,28 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 		if (req_id >= block_template->txn_count) {
 			// error....
 			pthread_rwlock_unlock(&datum_jobs_rwlock);
+			// error response to 0x50 0x11
+			i = 0; // reset index
+			msg[i] = 0x50; i++;
+			msg[i] = 0x91; i++;
+			msg[i] = job_index; i++;
+			msg[i] = 0xF4; i++;
+			
+			// pad with some randomness
+			j = 1 + (rand() % 100);
+			memset(&msg[i], rand(), j);
+			i+=j;
+			
+			datum_protocol_mining_cmd(msg, i);
+			return 1;
+		}
+		
+		// The count gate above does not stop a request that names the same
+		// index repeatedly, so bound the reply as it grows rather than trust
+		// the list to sum to at most one block.
+		if (!datum_protocol_stxlist_reply_fits((size_t)i, block_template->txns[req_id].size)) {
+			pthread_rwlock_unlock(&datum_jobs_rwlock);
+			DLOG_WARN("DATUM server requested %u transactions for job %d, more than one reply can carry; refusing", (unsigned)req_count, (int)job_index);
 			// error response to 0x50 0x11
 			i = 0; // reset index
 			msg[i] = 0x50; i++;
@@ -869,7 +920,7 @@ int datum_protocol_job_validation_cmd(int len, unsigned char *data) {
 		case 0x11: {
 			// send the requested txns
 			// 16-bit indexes
-			return datum_protocol_job_validation_stxlist_byid(p);
+			return datum_protocol_job_validation_stxlist_byid(len - 1, p);
 			break;
 		}
 		


### PR DESCRIPTION
## What
Bounds the 0x50 0x11 missing-transaction reply to what `datum_protocol_bulk_cmd` accepts, and refuses an index list shorter than its count before reading it. Both cases answer with the existing 0xF4 error.

## Why
`datum_protocol_job_validation_stxlist_byid` copies each requested transaction into `temp_data` with no check on the running total. The only gate is count at most `txn_count`, and nothing stops the list from naming the same index every time, so 64 copies of a 100 KB transaction's index produce a 6.4 MB reply into a 4.2 MB buffer, which in .bss sits in front of the job lock and the job table. The list was also read past the message length, since the handler never received it. Only the pool a gateway is connected to can send this message, so the exposure is a compromised or hostile pool server. The handler here is byte-identical to the one this fix went into at CONVOYMining/datum_gateway#2.

## How I tested
Rebased onto dbc3b14, gcc with `-Wall -Werror` builds clean, `--test` passes. This tree has no protocol test harness; the CONVOY PR carries a unit test that requests one 100 KB transaction 64 times and shows glibc's fortify check aborting without the bound and the reply refused with it.

## Risk and rollback
Only a request that would overflow, or whose list is shorter than its count, changes behavior, and those now get 0xF4 instead of memory corruption. A legitimate reply larger than the buffer could never be sent anyway. Revert the commit.
