### PR TITLE
protocol: Bound the job-validation parser and guard clz(0)

### DIFF
--- a/src/datum_protocol.c
+++ b/src/datum_protocol.c
@@ -450,7 +450,8 @@ err:
 	return 1;
 }
 
-int datum_protocol_job_validation_stxlist(unsigned char *data) {
+int datum_protocol_job_validation_stxlist(int len, unsigned char *data) {
+	if (len < 1) return 0;
 	// similar to compact blocks, we're going to send a list of short transaction IDs for the requested job
 	unsigned char job_index = data[0];
 	T_DATUM_PROTOCOL_JOB *dj;
@@ -609,7 +610,8 @@ int datum_protocol_job_validation_stxlist(unsigned char *data) {
 	return 1;
 }
 
-int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
+int datum_protocol_job_validation_stxlist_byid(int len, unsigned char *data) {
+	if (len < 3) return 0;
 	// the server is requesting missing transactions
 	// send them
 	unsigned char job_index = data[0];
@@ -705,6 +707,11 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 	pk_u16le(msg, i, req_count); i += 2;
 	
 	for(j=0;j<req_count;j++) {
+		if (k + 2 > len) {
+			// The server asked for more ids than it sent.
+			pthread_rwlock_unlock(&datum_jobs_rwlock);
+			return 0;
+		}
 		req_id = upk_u16le(data, k); k += 2;
 		
 		if (req_id >= block_template->txn_count) {
@@ -750,7 +757,8 @@ int datum_protocol_job_validation_stxlist_byid(unsigned char *data) {
 	return 1;
 }
 
-int datum_protocol_job_validation_sblock(unsigned char *data) {
+int datum_protocol_job_validation_sblock(int len, unsigned char *data) {
+	if (len < 1) return 0;
 	// the server decided our template probably is too unique from what it knows about, or was
 	// otherwise not able to validate the block using faster negotiations.
 	// It would like us to just send the entire transaction blob for validation as-is.
@@ -851,31 +859,29 @@ int datum_protocol_job_validation_sblock(unsigned char *data) {
 }
 
 int datum_protocol_job_validation_cmd(int len, unsigned char *data) {
-	unsigned char cmd = data[0];
-	unsigned char *p = data;
-	
 	if (len < 2) return 0;
 	
-	p++;
+	const unsigned char cmd = data[0];
+	unsigned char *p = data + 1;
 	
 	// sub sub cmd
 	switch (cmd) {
 		case 0x10: {
 			// send short txn list
-			return datum_protocol_job_validation_stxlist(p);
+			return datum_protocol_job_validation_stxlist(len - 1, p);
 			break;
 		}
 		
 		case 0x11: {
 			// send the requested txns
 			// 16-bit indexes
-			return datum_protocol_job_validation_stxlist_byid(p);
+			return datum_protocol_job_validation_stxlist_byid(len - 1, p);
 			break;
 		}
 		
 		case 0x12: {
 			// send the entire block, except the coinbase txn
-			return datum_protocol_job_validation_sblock(p);
+			return datum_protocol_job_validation_sblock(len - 1, p);
 			break;
 		}
 		// TODO: Implement a job differences mechanism to save bandwidth on new work vs stxids

--- a/src/datum_utils.c
+++ b/src/datum_utils.c
@@ -105,6 +105,7 @@ void datum_utils_init(void) {
 #ifdef __GNUC__
 // faster, less portable
 uint64_t roundDownToPowerOfTwo_64(uint64_t x) {
+	if (x == 0) return 0;  // __builtin_clzll(0) is undefined
 	return 1ULL << (63 - __builtin_clzll(x));
 }
 


### PR DESCRIPTION
## What
Two out-of-bounds reads in the DATUM protocol parser, both reachable from the pool the gateway connects to. Same code as CONVOY, where these went up as separate PRs.

- `datum_protocol_job_validation_cmd()` read the subcommand byte before its `len < 2` check and passed no length to the stxlist, stxlist-by-id and sblock handlers. `_stxlist_byid()` then read a three-byte header and two bytes per requested id, the id count bounded only against the template's transaction count, never against the received length. A short or crafted request reads past the frame, and with a valid job the surplus is copied into the reply and sent back to the pool.
- `roundDownToPowerOfTwo_64(0)` evaluated `1ULL << (63 - __builtin_clzll(0))`; `__builtin_clzll(0)` is undefined. `floorPoT()` next to it already guarded its zero case. Reached through a server minimum-difficulty of 0 and through the vardiff path.

## Why
`datum_protocol_mining_cmd5()` dispatches with `cmd_len` taken from the server's header, and the receive loop delivers exactly that many bytes, which can be as few as one, so the handlers read frames shorter than they assume. `server_recv_buffer` is a large static array, so on x86 these are reads of stale bytes rather than faults, but they are out-of-bounds reads of attacker-influenced length in a network parser.

## How I tested
Found by a libFuzzer harness over `datum_protocol_mining_cmd5` on the CONVOY tree; the same functions are byte-identical here. Built this fork with `gcc -Wall -Werror`, `datum_gateway --test` passes, and the three reproducing inputs replay clean under AddressSanitizer and UndefinedBehaviorSanitizer with the fixes. Each guard is a `return 0` on a frame too short for what the code then reads, a no-op on well-formed traffic.

## Risk and rollback
Valid pool traffic takes the same path. Revert either commit independently.
